### PR TITLE
Add copy feedback for share links

### DIFF
--- a/layouts/w/single.html
+++ b/layouts/w/single.html
@@ -26,27 +26,18 @@
 <p>Outcome: <strong>{{ lower .Params.state.gameStatus}}</strong></p>
 <p>Hard Mode: <strong>{{ .Params.state.hardMode}}</strong></p>
 <p>{{ partial "emoji-grid" . }}</p>
-<p>Share: ↘️ <a id="share-button" href="">Standard</a> | ↘️ <a id="share-enhanced" href="">Enhanced</a> | ↘️ <a id="share-spoilers" href="">Spoilers</a></p>
+<p>Share: ↘️ <a id="share-button" href="">Standard</a> | ↘️ <a id="share-enhanced" href="">Enhanced</a> | ↘️ <a id="share-spoilers" href="">Spoilers</a> <span id="share-copied" style="display:none;">✅ copied</span></p>
 <script>
-  function shareClick() {
-    navigator.clipboard.writeText({{ partial "share-standard" . }})
-    return false
+  function copyAndShow(text) {
+    navigator.clipboard.writeText(text);
+    const msg = document.getElementById("share-copied");
+    msg.style.display = "inline";
+    setTimeout(() => { msg.style.display = "none"; }, 1000);
+    return false;
   }
-  document.getElementById("share-button").onclick = shareClick
-</script>
-<script>
-  function shareClick() {
-    navigator.clipboard.writeText({{ partial "share-enhanced" . }})
-    return false
-  }
-  document.getElementById("share-enhanced").onclick = shareClick
-</script>
-<script>
-  function shareClick() {
-    navigator.clipboard.writeText({{ partial "share-spoilers" . }})
-    return false
-  }
-  document.getElementById("share-spoilers").onclick = shareClick
+  document.getElementById("share-button").onclick = function () { return copyAndShow({{ partial "share-standard" . }}); };
+  document.getElementById("share-enhanced").onclick = function () { return copyAndShow({{ partial "share-enhanced" . }}); };
+  document.getElementById("share-spoilers").onclick = function () { return copyAndShow({{ partial "share-spoilers" . }}); };
 </script>
 
 {{ $achievements := slice }}


### PR DESCRIPTION
## Summary
- show a small `copied` indicator when any share link is clicked
- reuse a single script for all share links

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_6867dd2756948323a20f46222b4ba602