### PR TITLE
Add copy feedback for share links

### DIFF
--- a/layouts/w/single.html
+++ b/layouts/w/single.html
@@ -27,26 +27,18 @@
 <p>Hard Mode: <strong>{{ .Params.state.hardMode}}</strong></p>
 <p>{{ partial "emoji-grid" . }}</p>
 <p>Share: ↘️ <a id="share-button" href="">Standard</a> | ↘️ <a id="share-enhanced" href="">Enhanced</a> | ↘️ <a id="share-spoilers" href="">Spoilers</a></p>
+<p id="share-copied" style="display:none;">✅ copied</p>
 <script>
-  function shareClick() {
-    navigator.clipboard.writeText({{ partial "share-standard" . }})
-    return false
+  function copyAndShow(text) {
+    navigator.clipboard.writeText(text);
+    const msg = document.getElementById("share-copied");
+    msg.style.display = "block";
+    setTimeout(() => { msg.style.display = "none"; }, 1000);
+    return false;
   }
-  document.getElementById("share-button").onclick = shareClick
-</script>
-<script>
-  function shareClick() {
-    navigator.clipboard.writeText({{ partial "share-enhanced" . }})
-    return false
-  }
-  document.getElementById("share-enhanced").onclick = shareClick
-</script>
-<script>
-  function shareClick() {
-    navigator.clipboard.writeText({{ partial "share-spoilers" . }})
-    return false
-  }
-  document.getElementById("share-spoilers").onclick = shareClick
+  document.getElementById("share-button").onclick = function () { return copyAndShow({{ partial "share-standard" . }}); };
+  document.getElementById("share-enhanced").onclick = function () { return copyAndShow({{ partial "share-enhanced" . }}); };
+  document.getElementById("share-spoilers").onclick = function () { return copyAndShow({{ partial "share-spoilers" . }}); };
 </script>
 
 {{ $achievements := slice }}


### PR DESCRIPTION
## Summary
- show copy indicator below share links on puzzle page
- adjust script to display indicator as block element

## Testing
- `hugo --minify`


------
https://chatgpt.com/codex/tasks/task_e_6867dd2756948323a20f46222b4ba602