### PR TITLE
Add annual calendar view for Wordle puzzles

### DIFF
--- a/content/w/2021/_index.md
+++ b/content/w/2021/_index.md
@@ -1,0 +1,7 @@
+---
+title: "2021"
+year: 2021
+layout: year
+---
+
+Puzzles from 2021.

--- a/content/w/2022/_index.md
+++ b/content/w/2022/_index.md
@@ -1,0 +1,7 @@
+---
+title: "2022"
+year: 2022
+layout: year
+---
+
+Puzzles from 2022.

--- a/content/w/2023/_index.md
+++ b/content/w/2023/_index.md
@@ -1,0 +1,7 @@
+---
+title: "2023"
+year: 2023
+layout: year
+---
+
+Puzzles from 2023.

--- a/content/w/2024/_index.md
+++ b/content/w/2024/_index.md
@@ -1,0 +1,7 @@
+---
+title: "2024"
+year: 2024
+layout: year
+---
+
+Puzzles from 2024.

--- a/content/w/2025/_index.md
+++ b/content/w/2025/_index.md
@@ -1,0 +1,7 @@
+---
+title: "2025"
+year: 2025
+layout: year
+---
+
+Puzzles from 2025.

--- a/layouts/partials/calendar-year.html
+++ b/layouts/partials/calendar-year.html
@@ -1,0 +1,40 @@
+{{ $year := .year }}
+{{ $puzzles := .puzzles }}
+
+{{ $puzzleMap := dict }}
+{{ range $p := $puzzles }}
+  {{ $key := $p.Date.Format "2006-01-02" }}
+  {{ $puzzleMap = merge $puzzleMap (dict $key $p) }}
+{{ end }}
+
+{{ $weekdayMap := dict "Sunday" 0 "Monday" 1 "Tuesday" 2 "Wednesday" 3 "Thursday" 4 "Friday" 5 "Saturday" 6 }}
+{{ range $m := seq 1 12 }}
+  {{ $monthStart := time (printf "%04d-%02d-01" $year $m) }}
+  {{ $nextMonth := $monthStart.AddDate 0 1 0 }}
+  {{ $daysInMonth := ($nextMonth.AddDate 0 0 -1).Day }}
+  <h3>{{ $monthStart.Format "January" }}</h3>
+  <table>
+    <tr><th>Sun</th><th>Mon</th><th>Tue</th><th>Wed</th><th>Thu</th><th>Fri</th><th>Sat</th></tr>
+    {{ $firstW := index $weekdayMap ($monthStart.Format "Monday") }}
+    <tr>
+      {{ range seq 0 (sub $firstW 1) }}<td></td>{{ end }}
+      {{ $w := $firstW }}
+      {{ range $d := seq 1 $daysInMonth }}
+        {{ if ge $w 7 }}
+          </tr>
+          <tr>
+          {{ $w = 0 }}
+        {{ end }}
+        {{ $dateKey := printf "%04d-%02d-%02d" $year $m $d }}
+        <td>
+          {{ with index $puzzleMap $dateKey }}
+            <a href="{{ .RelPermalink }}">{{ index .Params.puzzles 0 }}</a><br />
+            {{ partial "guess-count.html" . }}
+          {{ end }}
+        </td>
+        {{ $w = add $w 1 }}
+      {{ end }}
+      {{ range seq $w 6 }}<td></td>{{ end }}
+    </tr>
+  </table>
+{{ end }}

--- a/layouts/w/list.html
+++ b/layouts/w/list.html
@@ -16,7 +16,7 @@
     <td>Grid</td>
   </tr>
 
-  {{ range .Data.Pages }}
+  {{ range where .Data.Pages "Kind" "page" }}
     <tr>
       <td><a href="{{ .RelPermalink }}">{{ dateFormat "Jan 2, 2006" .Date }}</a></td>
       <td><a href="{{ with $.GetPage (printf "/puzzles/%s" (index .Params.puzzles 0)) }}{{ .RelPermalink}}{{end}}">{{ index .Params.puzzles 0 }}</a></td>

--- a/layouts/w/year.html
+++ b/layouts/w/year.html
@@ -1,0 +1,13 @@
+{{ define "main" }}
+<h1>{{ .Title }}</h1>
+<p>{{ partial "breadcrumb.html" . }}</p>
+{{ $year := .Params.year }}
+{{ if not $year }}
+  {{ $year = .Title }}
+{{ end }}
+{{ $allPuzzles := where .Site.RegularPages "Section" "w" }}
+{{ $start := time (printf "%d-01-01" (int $year)) }}
+{{ $end := $start.AddDate 1 0 0 }}
+{{ $yearPuzzles := where (where $allPuzzles "Date" "ge" $start) "Date" "lt" $end }}
+{{ partial "calendar-year.html" (dict "year" $year "puzzles" $yearPuzzles) }}
+{{ end }}


### PR DESCRIPTION
## Summary
- introduce new yearly calendar layout for Wordle puzzles
- render monthly calendars with guess count indicator
- adjust list view to ignore year index pages
- add `_index.md` files for each year and use the calendar layout

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_686db42f21b883239cb80e0769a802be