### PR TITLE
Add year navigation

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -39,6 +39,13 @@
   💡 <a href="{{ with .Site.GetPage "a/how-it-works" }}{{ .RelPermalink }}{{ end }}">How Does This Website Work?</a>
 </blockquote>
 
+  {{ $years := (where .Site.RegularPages "Section" "w").GroupByDate "2006" }}
+  <div>📅 Calendars:
+    {{ range $index, $year := $years }}
+      {{ with $.Site.GetPage (printf "/w/%s" $year.Key) }}<a href="{{ .RelPermalink }}">{{ $year.Key }}</a>{{ if lt (add $index 1) (len $years) }}, {{ end }}{{ end }}
+    {{ end }}
+  </div>
+
 <h2>🕰 Recent Puzzles</h2>
 <table>
   <tr>

--- a/layouts/w/list.html
+++ b/layouts/w/list.html
@@ -3,6 +3,13 @@
 
 <p>{{ partial "breadcrumb.html" . }}</p>
 
+{{ $yearGroups := (where .Site.RegularPages "Section" "w").GroupByDate "2006" }}
+<p>
+  {{ range $index, $y := $yearGroups }}
+    {{ with $.Site.GetPage (printf "/w/%s" $y.Key) }}<a href="{{ .RelPermalink }}">{{ $y.Key }}</a>{{ if lt (add $index 1) (len $yearGroups) }}, {{ end }}{{ end }}
+  {{ end }}
+</p>
+
 {{ with .Content }}
 <div>{{ . }}</div>
 {{ end }}


### PR DESCRIPTION
## Summary
- add list of calendar years to homepage
- show year links at top of wordle list page

## Testing
- `hugo --quiet`


------
https://chatgpt.com/codex/tasks/task_e_686df97093d48323aa5e77482b8eee62