### PR TITLE
Fix duplicate sparkle on failed puzzles

### DIFF
--- a/layouts/w/single.html
+++ b/layouts/w/single.html
@@ -118,7 +118,7 @@
               <a 
                 {{ cond $isSolvingGuess ((printf "style=%q" $rowBackgroundColor) | safeHTMLAttr ) "" }} 
                   href="{{ .RelPermalink }}">
-                  {{ $guess }} {{ cond $isSolvingGuess "✨" ""}}
+                  {{ $guess }} {{ cond (and $isSolvingGuess (ne (lower $.Params.state.gameStatus) "fail")) "✨" ""}}
               </a>
             </td>
             {{ $guessHistory := index $.Site.Taxonomies.words $guess }}


### PR DESCRIPTION
## Summary
- avoid showing a sparkle on the guess row when the puzzle was failed

## Testing
- `hugo --templateMetrics > /tmp/hugo-build-stats.txt`

------
https://chatgpt.com/codex/tasks/task_e_68708c6f70b88323b52c4ea49717947d