### PR TITLE
Add 2021 puzzle hashes and shifts

### DIFF
--- a/content/w/2021-12-04/index.md
+++ b/content/w/2021-12-04/index.md
@@ -4,6 +4,8 @@ title: "168: 2021-12-04"
 aliases: ['/w/168']
 date: 2021-12-04T12:00:00.000-08:00
 puzzles: [168]
+hashes: ["PPAAAAAPPACAAACCPAACCCCCCXXXXX"]
+shifts: ["kecud"]
 tags: ['backfill']
 words: [
   "tenor",

--- a/content/w/2021-12-05/index.md
+++ b/content/w/2021-12-05/index.md
@@ -49,6 +49,8 @@ state:
 stats: {}
 puzzles:
   - 169
+hashes: ["APAAPPAAPPPPPCACCCCCXXXXXXXXXX"]
+shifts: ["azpnb"]
 aliases:
   - /w/169/
 ---

--- a/content/w/2021-12-06/index.md
+++ b/content/w/2021-12-06/index.md
@@ -44,6 +44,8 @@ state:
 stats: {}
 puzzles:
   - 170
+hashes: ["AAPPACAAPACCCCCXXXXXXXXXXXXXXX"]
+shifts: ["kwwlr"]
 aliases:
   - /w/170/
 ---

--- a/content/w/2021-12-07/index.md
+++ b/content/w/2021-12-07/index.md
@@ -44,6 +44,8 @@ state:
 stats: {}
 puzzles:
   - 171
+hashes: ["APAAPCPCAACCCCCXXXXXXXXXXXXXXX"]
+shifts: ["zyqjn"]
 aliases:
   - /w/171/
 ---

--- a/content/w/2021-12-08/index.md
+++ b/content/w/2021-12-08/index.md
@@ -49,6 +49,8 @@ state:
 stats: {}
 puzzles:
   - 172
+hashes: ["PAAAAAPPAAACCCCCCCCCXXXXXXXXXX"]
+shifts: ["hymju"]
 aliases:
   - /w/172/
 ---

--- a/content/w/2021-12-09/index.md
+++ b/content/w/2021-12-09/index.md
@@ -49,6 +49,8 @@ state:
 stats: {}
 puzzles:
   - 173
+hashes: ["APAPAACAPPACCPACCCCCXXXXXXXXXX"]
+shifts: ["xoqwy"]
 aliases:
   - /w/173/
 ---

--- a/content/w/2021-12-10/index.md
+++ b/content/w/2021-12-10/index.md
@@ -49,6 +49,8 @@ state:
 stats: {}
 puzzles:
   - 174
+hashes: ["ACAAAPCAAAPCACPCCCCCXXXXXXXXXX"]
+shifts: ["bpzjv"]
 aliases:
   - /w/174/
 ---

--- a/content/w/2021-12-11/index.md
+++ b/content/w/2021-12-11/index.md
@@ -59,6 +59,8 @@ state:
 stats: {}
 puzzles:
   - 175
+hashes: ["AAAAAAPPAAACAPAPCACCACCCCACCCC"]
+shifts: ["ivvrm"]
 aliases:
   - /w/175/
 ---

--- a/content/w/2021-12-12/index.md
+++ b/content/w/2021-12-12/index.md
@@ -59,6 +59,8 @@ state:
 stats: {}
 puzzles:
   - 176
+hashes: ["PAAAAAPPAPPAPPAACCPAACCACCCCCC"]
+shifts: ["shabo"]
 aliases:
   - /w/176/
 ---

--- a/content/w/2021-12-13/index.md
+++ b/content/w/2021-12-13/index.md
@@ -45,6 +45,8 @@ state:
 stats: {}
 puzzles:
   - 177
+hashes: ["AAAAACCAPACCCCCXXXXXXXXXXXXXXX"]
+shifts: ["yvvrm"]
 aliases:
   - /w/177/
 ---

--- a/content/w/2021-12-14/index.md
+++ b/content/w/2021-12-14/index.md
@@ -49,6 +49,8 @@ state:
 stats: {}
 puzzles:
   - 178
+hashes: ["PAAAAAPAPPPCACCCCCCCXXXXXXXXXX"]
+shifts: ["bpbjv"]
 aliases:
   - /w/178/
 ---

--- a/content/w/2021-12-15/index.md
+++ b/content/w/2021-12-15/index.md
@@ -54,6 +54,8 @@ state:
 stats: {}
 puzzles:
   - 179
+hashes: ["AAAPPPPCCAACCCCACCCCCCCCCXXXXX"]
+shifts: ["zyilo"]
 aliases:
   - /w/179/
 ---

--- a/content/w/2021-12-19/index.md
+++ b/content/w/2021-12-19/index.md
@@ -49,6 +49,8 @@ state:
 stats: {}
 puzzles:
   - 183
+hashes: ["APAPAPAPAAACCAACCCCCXXXXXXXXXX"]
+shifts: ["hhbxx"]
 aliases:
   - /w/183/
 ---

--- a/content/w/2021-12-20/index.md
+++ b/content/w/2021-12-20/index.md
@@ -54,6 +54,8 @@ state:
 stats: {}
 puzzles:
   - 184
+hashes: ["AAAPPACAACACAACCCCACCCCCCXXXXX"]
+shifts: ["hyito"]
 aliases:
   - /w/184/
 ---

--- a/content/w/2021-12-21/index.md
+++ b/content/w/2021-12-21/index.md
@@ -43,6 +43,8 @@ state:
 stats: {}
 puzzles:
   - 185
+hashes: ["PAAAAACACCCCCCCXXXXXXXXXXXXXXX"]
+shifts: ["vsclu"]
 aliases:
   - /w/185/
 ---

--- a/content/w/2021-12-22/index.md
+++ b/content/w/2021-12-22/index.md
@@ -54,6 +54,8 @@ state:
 stats: {}
 puzzles:
   - 186
+hashes: ["ACCACACCACACCACCCCACCCCCCXXXXX"]
+shifts: ["iyiio"]
 aliases:
   - /w/186/
 ---

--- a/content/w/2021-12-23/index.md
+++ b/content/w/2021-12-23/index.md
@@ -54,6 +54,8 @@ state:
 stats: {}
 puzzles:
   - 187
+hashes: ["AAPAAAAAACAPAPCCCCACCCCCCXXXXX"]
+shifts: ["myqyo"]
 aliases:
   - /w/187/
 ---

--- a/content/w/2021-12-24/index.md
+++ b/content/w/2021-12-24/index.md
@@ -54,6 +54,8 @@ state:
 stats: {}
 puzzles:
   - 188
+hashes: ["ACCCAACCCAACCCAACCCACCCCCXXXXX"]
+shifts: ["cliai"]
 aliases:
   - /w/188/
 ---

--- a/content/w/2021-12-25/index.md
+++ b/content/w/2021-12-25/index.md
@@ -49,6 +49,8 @@ state:
 stats: {}
 puzzles:
   - 189
+hashes: ["AAAAACCAPACCCCACCCCCXXXXXXXXXX"]
+shifts: ["vpkti"]
 aliases:
   - /w/189/
 ---

--- a/content/w/2021-12-26/index.md
+++ b/content/w/2021-12-26/index.md
@@ -50,6 +50,8 @@ state:
 stats: {}
 puzzles:
   - 190
+hashes: ["AAPPAAPPPAAPPPACCCCCXXXXXXXXXX"]
+shifts: ["gjcco"]
 aliases:
   - /w/190/
 ---

--- a/content/w/2021-12-27/index.md
+++ b/content/w/2021-12-27/index.md
@@ -59,6 +59,8 @@ state:
 stats: {}
 puzzles:
   - 191
+hashes: ["APAAPPAAPAAAPCCACCCCACCCCCCCCC"]
+shifts: ["llzai"]
 aliases:
   - /w/191/
 ---

--- a/content/w/2021-12-29/index.md
+++ b/content/w/2021-12-29/index.md
@@ -49,6 +49,8 @@ state:
 stats: {}
 puzzles:
   - 193
+hashes: ["APAPACPPCACPPCACCCCCXXXXXXXXXX"]
+shifts: ["zhxrb"]
 aliases:
   - /w/193/
 ---

--- a/content/w/2021-12-30/index.md
+++ b/content/w/2021-12-30/index.md
@@ -49,6 +49,8 @@ state:
 stats: {}
 puzzles:
   - 194
+hashes: ["APCAAAACACAACACCCCCCXXXXXXXXXX"]
+shifts: ["zywuv"]
 aliases:
   - /w/194/
 ---

--- a/content/w/2021-12-31/index.md
+++ b/content/w/2021-12-31/index.md
@@ -49,6 +49,8 @@ state:
 stats: {}
 puzzles:
   - 195
+hashes: ["AAAAAAACPACCCAACCCCCXXXXXXXXXX"]
+shifts: ["auqoi"]
 aliases:
   - /w/195/
 ---


### PR DESCRIPTION
## Summary
- backfill `hashes` and `shifts` metadata for all puzzles in 2021

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6881b50d94b88323b986f4887935dc30