### PR TITLE
Order hash taxonomy by frequency

### DIFF
--- a/layouts/taxonomy/hash.terms.html
+++ b/layouts/taxonomy/hash.terms.html
@@ -16,11 +16,14 @@
     <td>Last Played</td>
   </tr>
 
-  {{ range .Data.Terms.Alphabetical }}
-    {{ $name := .Name }}
-    {{ $count := .Count }}
-    {{ $first := index (first 1 .Pages.ByDate) 0 }}
-    {{ $last := index (last 1 .Pages.ByDate) 0 }}
+  {{ $alphabetical := .Data.Terms.Alphabetical }}
+  {{ $ordered := sort $alphabetical "Count" "desc" }}
+
+  {{ range $term := $ordered }}
+    {{ $name := $term.Name }}
+    {{ $count := $term.Count }}
+    {{ $first := index (first 1 $term.Pages.ByDate) 0 }}
+    {{ $last := index (last 1 $term.Pages.ByDate) 0 }}
 
     {{ with $.Site.GetPage (printf "/%s/%s" "hashes" $name) }}
     <tr>


### PR DESCRIPTION
## Summary
- order hashes taxonomy by frequency

## Testing
- `hugo --quiet -s .`


------
https://chatgpt.com/codex/tasks/task_e_68838a8fe3a08323b033887db92c1411