### PR TITLE
Enable unsafe HTML rendering for Tetris 99 post

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -23,6 +23,9 @@ enableInlineShortcodes = true
     endLevel = 3
     ordered = false
     startLevel = 1
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true
 
 [outputFormats]
   [outputFormats.p8s]


### PR DESCRIPTION
## Summary
- allow raw HTML in Markdown so embeds like the Tetris 99 post render

## Testing
- `hugo --quiet`

------
https://chatgpt.com/codex/tasks/task_e_689178ad68f08323b899152dee6627b5