### PR TITLE
fix: correct Caesar shift for 2025-09-02

### DIFF
--- a/content/w/2025-09-02/index.md
+++ b/content/w/2025-09-02/index.md
@@ -9,7 +9,7 @@ openers: ["count"]
 middlers: ["blast","greet","digit","fight"]
 puzzles: [1536]
 hashes: ["AAAACAAAACPAAACACCACACCCCACCCC"]
-shifts: ["cpoqd"]
+shifts: ["spoqd"]
 state: {
   "puzzleDate": "2025-09-02",
   "boardState": [


### PR DESCRIPTION
## Summary
- fix Caesar shift encoding for puzzle 2025-09-02 by applying sequential +6 to +10 offsets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d86bed788323b73a68928b3d04fd