### PR TITLE
Fix incorrect shift for 2022-11-25 puzzle

### DIFF
--- a/content/w/2022-11-25/index.md
+++ b/content/w/2022-11-25/index.md
@@ -6,7 +6,7 @@ contests: ["2022-11-habit"]
 words: ["habit","third","itchy"]
 puzzles: [524]
 hashes: ["PAAPPPPPAACCCCCXXXXXXXXXXXXXXX"]
-shifts: ["jvfld"]
+shifts: ["oakqi"]
 state: {
   "boardState": [
     "habit",


### PR DESCRIPTION
## Summary
- Verify shift encodings for all Wordle puzzle history
- Correct 2022-11-25 puzzle shift from `jvfld` to `oakqi`

## Testing
- `python - <<'PY' ...` (verified all shifts)
- `hugo -s . -d /tmp/build`


------
https://chatgpt.com/codex/tasks/task_e_68b84a117324832392609da974a96657