### PR TITLE
Fix shift encoding on May 15 Wordle loss

### DIFF
--- a/content/w/2025-05-15/index.md
+++ b/content/w/2025-05-15/index.md
@@ -6,10 +6,10 @@ git_branch: 2025-05-15_1426
 contests: []
 words: ["scout","plane","freak","gamer","rager","wager"]
 openers: ["scout"]
-middlers: ["plane","freak","gamer","rager","wager"]
+middlers: ["plane","freak","gamer","rager"]
 puzzles: [1426]
 hashes: ["AAAAAAAPAPAPPPAPCACCACCCCACCCC"]
-shifts: ["chonb"]
+shifts: ["khonb"]
 state: {
   "puzzleDate": "2025-05-15",
   "boardState": [


### PR DESCRIPTION
## Summary
- correct middle guess list and Caesar-shifted solution for the 2025-05-15 loss entry

## Testing
- `hugo -d /tmp/out`

------
https://chatgpt.com/codex/tasks/task_e_68b988dcd0b883238f3c2eecbe4683bc