### PR TITLE
Add non-opener word usage report

### DIFF
--- a/content/non-opener-usage.md
+++ b/content/non-opener-usage.md
@@ -6,32 +6,26 @@ Words that have been used outside the opener, sorted by non-opener usage.
 
 {{< om.inline >}}
   {{ $wordles := where .Site.RegularPages "Section" "w" }}
-  {{ $data := partial "non-openers.html" $wordles }}
-  {{ $words := sort $data.wordCounts "count" "desc" }}
+  {{ $openers := partial "openers.html" $wordles }}
+  {{ $nonOpeners := partial "non-openers.html" $wordles }}
+  {{ $words := sort $nonOpeners "count" "desc" }}
 
-  <p>Distinct Opening Words Used: <strong>{{ $data.counts.openers }}</strong></p>
-  <p>Distinct Non-Opener Words Used: <strong>{{ $data.counts.nonOpeners }}</strong></p>
-  <p>Total Distinct Words Used: <strong>{{ $data.counts.total }}</strong></p>
+  <p>Distinct Opening Words Used: <strong>{{ len $openers.wordCounts }}</strong></p>
+  <p>Distinct Non-Opener Words Used: <strong>{{ len $nonOpeners }}</strong></p>
+  <p>Total Distinct Words Used: <strong>{{ add (len $openers.wordCounts) (len $nonOpeners) }}</strong></p>
 
   <table>
     <tr>
       <th>Word</th>
       <th>Non-Opener Uses</th>
-      <th>1</th>
-      <th>2</th>
-      <th>3</th>
-      <th>4</th>
-      <th>5</th>
-      <th>6</th>
+      <th>Guesses</th>
     </tr>
     {{ range $words }}
       {{ $w := . }}
       <tr>
         <td>{{ $w.word }}</td>
         <td>{{ $w.count }}</td>
-        {{ range $slot := seq 1 6 }}
-          <td>{{ if index $w.slots (string $slot) }}✅{{ else }}❌{{ end }}</td>
-        {{ end }}
+        <td>{{ range $slot := seq 1 6 }}{{ if index $w.slots (string $slot) }}✅{{ else }}❌{{ end }}{{ end }}</td>
       </tr>
     {{ end }}
   </table>

--- a/content/non-opener-usage.md
+++ b/content/non-opener-usage.md
@@ -10,7 +10,6 @@ Words that have been used outside the opener, sorted by non-opener usage.
   {{ $nonOpeners := partial "non-openers.html" $wordles }}
   {{ $words := sort $nonOpeners "count" "desc" }}
 
-  <p>Distinct Opening Words Used: <strong>{{ len $openers.wordCounts }}</strong></p>
   <p>Distinct Non-Opener Words Used: <strong>{{ len $nonOpeners }}</strong></p>
   <p>Total Distinct Words Used: <strong>{{ add (len $openers.wordCounts) (len $nonOpeners) }}</strong></p>
 
@@ -23,7 +22,7 @@ Words that have been used outside the opener, sorted by non-opener usage.
     {{ range $words }}
       {{ $w := . }}
       <tr>
-        <td>{{ $w.word }}</td>
+        <td>{{ with $.Site.GetPage (printf "/words/%s" $w.word) }}<a href="{{ .RelPermalink }}">{{ $w.word }}</a>{{ else }}{{ $w.word }}{{ end }}</td>
         <td>{{ $w.count }}</td>
         <td>{{ range $slot := seq 1 6 }}{{ if index $w.slots (string $slot) }}✅{{ else }}❌{{ end }}{{ end }}</td>
       </tr>

--- a/content/non-opener-usage.md
+++ b/content/non-opener-usage.md
@@ -1,0 +1,38 @@
+---
+title: Non-Opener Word Usage
+---
+
+Words that have been used outside the opener, sorted by non-opener usage.
+
+{{< om.inline >}}
+  {{ $wordles := where .Site.RegularPages "Section" "w" }}
+  {{ $data := partial "non-openers.html" $wordles }}
+  {{ $words := sort $data.wordCounts "count" "desc" }}
+
+  <p>Distinct Opening Words Used: <strong>{{ $data.counts.openers }}</strong></p>
+  <p>Distinct Non-Opener Words Used: <strong>{{ $data.counts.nonOpeners }}</strong></p>
+  <p>Total Distinct Words Used: <strong>{{ $data.counts.total }}</strong></p>
+
+  <table>
+    <tr>
+      <th>Word</th>
+      <th>Non-Opener Uses</th>
+      <th>1</th>
+      <th>2</th>
+      <th>3</th>
+      <th>4</th>
+      <th>5</th>
+      <th>6</th>
+    </tr>
+    {{ range $words }}
+      {{ $w := . }}
+      <tr>
+        <td>{{ $w.word }}</td>
+        <td>{{ $w.count }}</td>
+        {{ range $slot := seq 1 6 }}
+          <td>{{ if index $w.slots (string $slot) }}✅{{ else }}❌{{ end }}</td>
+        {{ end }}
+      </tr>
+    {{ end }}
+  </table>
+{{< /om.inline >}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -35,28 +35,9 @@
 {{ end }}
 <div>🧩 Total Guesses: <strong><a href="{{ with .Site.GetPage "guesses" }}{{ .RelPermalink }}{{ end }}">{{ $total_guesses }}</a></strong></div>
 <div>🧩 Guesses per Puzzle:  <strong>{{ (div (float $total_guesses) (len $wordles))  | lang.FormatNumber 2 }}</strong></div>
-<div>🧩 Distinct Opening Words Used: <strong>{{ len $openers.wordCounts }}</strong></div>
-<div>🧩 Distinct Non-Opener Words Used: <strong>{{ len $nonOpeners }}</strong></div>
-<div>🧩 Distinct Words Used: <strong><a href="{{ with .Site.GetPage "words" }}{{ .RelPermalink }}{{ end }}">{{ add (len $openers.wordCounts) (len $nonOpeners) }}</a></strong></div>
-
-{{ $sortedNon := sort $nonOpeners "count" "desc" }}
-<h2>🔥 Top Non-Opener Words</h2>
-<table>
-  <tr>
-    <th>Word</th>
-    <th>Non-Opener Uses</th>
-    <th>Guesses</th>
-  </tr>
-  {{ range first 10 $sortedNon }}
-    {{ $w := . }}
-    <tr>
-      <td>{{ $w.word }}</td>
-      <td>{{ $w.count }}</td>
-      <td>{{ range $slot := seq 1 6 }}{{ if index $w.slots (string $slot) }}✅{{ else }}❌{{ end }}{{ end }}</td>
-    </tr>
-  {{ end }}
-</table>
-<p><a href="{{ with .Site.GetPage "non-opener-usage.md" }}{{ .RelPermalink }}{{ end }}">Full list…</a></p>
+  <div>🧩 Distinct Words Used: <strong><a href="{{ with .Site.GetPage "words" }}{{ .RelPermalink }}{{ end }}">{{ add (len $openers.wordCounts) (len $nonOpeners) }}</a></strong></div>
+  <div>🧩 Distinct Opening Words Used: <strong><a href="{{ with .Site.GetPage "openers.md" }}{{ .RelPermalink }}{{ end }}">{{ len $openers.wordCounts }}</a></strong></div>
+  <div>🧩 Distinct Non-Opener Words Used: <strong><a href="{{ with .Site.GetPage "non-opener-usage.md" }}{{ .RelPermalink }}{{ end }}">{{ len $nonOpeners }}</a></strong></div>
 
 <blockquote>
   💡 <a href="{{ with .Site.GetPage "a/how-it-works" }}{{ .RelPermalink }}{{ end }}">How Does This Website Work?</a>
@@ -352,6 +333,25 @@
     <tr><td colspan="2"><a href="{{ .RelPermalink }}">🚪 See All Openers</a></td></tr>
   {{ end }}
 </table>
+
+{{ $sortedNon := sort $nonOpeners "count" "desc" }}
+<h2>🔥 Top Non-Opener Words</h2>
+<table>
+  <tr>
+    <th>Word</th>
+    <th>Non-Opener Uses</th>
+    <th>Guesses</th>
+  </tr>
+  {{ range first 10 $sortedNon }}
+    {{ $w := . }}
+    <tr>
+      <td>{{ with $.Site.GetPage (printf "/words/%s" $w.word) }}<a href="{{ .RelPermalink }}">{{ $w.word }}</a>{{ else }}{{ $w.word }}{{ end }}</td>
+      <td>{{ $w.count }}</td>
+      <td>{{ range $slot := seq 1 6 }}{{ if index $w.slots (string $slot) }}✅{{ else }}❌{{ end }}{{ end }}</td>
+    </tr>
+  {{ end }}
+</table>
+<p><a href="{{ with .Site.GetPage "non-opener-usage.md" }}{{ .RelPermalink }}{{ end }}">Full list…</a></p>
 
 <h2>🗓 Monthly Trends</h2>
 <table>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,6 +8,7 @@
 </blockquote>
 
 {{ $wordles := where .Site.RegularPages "Section" "w" }}
+{{ $openers := partial "openers.html" $wordles }}
 {{ $nonOpeners := partial "non-openers.html" $wordles }}
 {{ $wins := where $wordles "Params.state.gameStatus" "WIN" }}
 {{ $losses := where $wordles "Params.state.gameStatus" "FAIL"}}
@@ -34,31 +35,24 @@
 {{ end }}
 <div>🧩 Total Guesses: <strong><a href="{{ with .Site.GetPage "guesses" }}{{ .RelPermalink }}{{ end }}">{{ $total_guesses }}</a></strong></div>
 <div>🧩 Guesses per Puzzle:  <strong>{{ (div (float $total_guesses) (len $wordles))  | lang.FormatNumber 2 }}</strong></div>
-<div>🧩 Distinct Opening Words Used: <strong>{{ $nonOpeners.counts.openers }}</strong></div>
-<div>🧩 Distinct Non-Opener Words Used: <strong>{{ $nonOpeners.counts.nonOpeners }}</strong></div>
-<div>🧩 Distinct Words Used: <strong><a href="{{ with .Site.GetPage "words" }}{{ .RelPermalink }}{{ end }}">{{ $nonOpeners.counts.total }}</a></strong></div>
+<div>🧩 Distinct Opening Words Used: <strong>{{ len $openers.wordCounts }}</strong></div>
+<div>🧩 Distinct Non-Opener Words Used: <strong>{{ len $nonOpeners }}</strong></div>
+<div>🧩 Distinct Words Used: <strong><a href="{{ with .Site.GetPage "words" }}{{ .RelPermalink }}{{ end }}">{{ add (len $openers.wordCounts) (len $nonOpeners) }}</a></strong></div>
 
-{{ $sortedNon := sort $nonOpeners.wordCounts "count" "desc" }}
+{{ $sortedNon := sort $nonOpeners "count" "desc" }}
 <h2>🔥 Top Non-Opener Words</h2>
 <table>
   <tr>
     <th>Word</th>
     <th>Non-Opener Uses</th>
-    <th>1</th>
-    <th>2</th>
-    <th>3</th>
-    <th>4</th>
-    <th>5</th>
-    <th>6</th>
+    <th>Guesses</th>
   </tr>
   {{ range first 10 $sortedNon }}
     {{ $w := . }}
     <tr>
       <td>{{ $w.word }}</td>
       <td>{{ $w.count }}</td>
-      {{ range $slot := seq 1 6 }}
-        <td>{{ if index $w.slots (string $slot) }}✅{{ else }}❌{{ end }}</td>
-      {{ end }}
+      <td>{{ range $slot := seq 1 6 }}{{ if index $w.slots (string $slot) }}✅{{ else }}❌{{ end }}{{ end }}</td>
     </tr>
   {{ end }}
 </table>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,6 +8,7 @@
 </blockquote>
 
 {{ $wordles := where .Site.RegularPages "Section" "w" }}
+{{ $nonOpeners := partial "non-openers.html" $wordles }}
 {{ $wins := where $wordles "Params.state.gameStatus" "WIN" }}
 {{ $losses := where $wordles "Params.state.gameStatus" "FAIL"}}
 {{ $nyt_puzzle_count := 2309 }}
@@ -33,7 +34,35 @@
 {{ end }}
 <div>🧩 Total Guesses: <strong><a href="{{ with .Site.GetPage "guesses" }}{{ .RelPermalink }}{{ end }}">{{ $total_guesses }}</a></strong></div>
 <div>🧩 Guesses per Puzzle:  <strong>{{ (div (float $total_guesses) (len $wordles))  | lang.FormatNumber 2 }}</strong></div>
-<div>🧩 Distinct Words Guessed: <strong><a href="{{ with .Site.GetPage "words" }}{{ .RelPermalink }}{{ end }}">{{ len .Site.Taxonomies.words }}</a></strong></div>
+<div>🧩 Distinct Opening Words Used: <strong>{{ $nonOpeners.counts.openers }}</strong></div>
+<div>🧩 Distinct Non-Opener Words Used: <strong>{{ $nonOpeners.counts.nonOpeners }}</strong></div>
+<div>🧩 Distinct Words Used: <strong><a href="{{ with .Site.GetPage "words" }}{{ .RelPermalink }}{{ end }}">{{ $nonOpeners.counts.total }}</a></strong></div>
+
+{{ $sortedNon := sort $nonOpeners.wordCounts "count" "desc" }}
+<h2>🔥 Top Non-Opener Words</h2>
+<table>
+  <tr>
+    <th>Word</th>
+    <th>Non-Opener Uses</th>
+    <th>1</th>
+    <th>2</th>
+    <th>3</th>
+    <th>4</th>
+    <th>5</th>
+    <th>6</th>
+  </tr>
+  {{ range first 10 $sortedNon }}
+    {{ $w := . }}
+    <tr>
+      <td>{{ $w.word }}</td>
+      <td>{{ $w.count }}</td>
+      {{ range $slot := seq 1 6 }}
+        <td>{{ if index $w.slots (string $slot) }}✅{{ else }}❌{{ end }}</td>
+      {{ end }}
+    </tr>
+  {{ end }}
+</table>
+<p><a href="{{ with .Site.GetPage "non-opener-usage.md" }}{{ .RelPermalink }}{{ end }}">Full list…</a></p>
 
 <blockquote>
   💡 <a href="{{ with .Site.GetPage "a/how-it-works" }}{{ .RelPermalink }}{{ end }}">How Does This Website Work?</a>

--- a/layouts/partials/non-openers.html
+++ b/layouts/partials/non-openers.html
@@ -1,0 +1,34 @@
+{{ $usage := dict }}
+{{ $openerSet := dict }}
+{{ $nonOpenerSet := dict }}
+
+{{ range . }}
+  {{ $guesses := .Params.words }}
+  {{ if not $guesses }}
+    {{ $guesses = index .Params.state "boardState" }}
+  {{ end }}
+  {{ range $i, $word := $guesses }}
+    {{ if $word }}
+      {{ $entry := index $usage $word }}
+      {{ if not $entry }}
+        {{ $entry = dict "word" $word "count" 0 "slots" (dict "1" false "2" false "3" false "4" false "5" false "6" false) }}
+      {{ end }}
+      {{ $slot := add $i 1 }}
+      {{ $entry = merge $entry (dict "slots" (merge $entry.slots (dict (string $slot) true))) }}
+      {{ if gt $slot 1 }}
+        {{ $entry = merge $entry (dict "count" (add $entry.count 1)) }}
+        {{ $nonOpenerSet = merge $nonOpenerSet (dict $word true) }}
+      {{ else }}
+        {{ $openerSet = merge $openerSet (dict $word true) }}
+      {{ end }}
+      {{ $usage = merge $usage (dict $word $entry) }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ $wordCounts := slice }}
+{{ range $word, $entry := $usage }}
+  {{ $wordCounts = $wordCounts | append $entry }}
+{{ end }}
+
+{{ return (dict "wordCounts" $wordCounts "counts" (dict "openers" (len $openerSet) "nonOpeners" (len $nonOpenerSet) "total" (len $wordCounts))) }}

--- a/layouts/partials/non-openers.html
+++ b/layouts/partials/non-openers.html
@@ -1,6 +1,4 @@
 {{ $usage := dict }}
-{{ $openerSet := dict }}
-{{ $nonOpenerSet := dict }}
 
 {{ range . }}
   {{ $guesses := .Params.words }}
@@ -17,9 +15,6 @@
       {{ $entry = merge $entry (dict "slots" (merge $entry.slots (dict (string $slot) true))) }}
       {{ if gt $slot 1 }}
         {{ $entry = merge $entry (dict "count" (add $entry.count 1)) }}
-        {{ $nonOpenerSet = merge $nonOpenerSet (dict $word true) }}
-      {{ else }}
-        {{ $openerSet = merge $openerSet (dict $word true) }}
       {{ end }}
       {{ $usage = merge $usage (dict $word $entry) }}
     {{ end }}
@@ -28,7 +23,9 @@
 
 {{ $wordCounts := slice }}
 {{ range $word, $entry := $usage }}
-  {{ $wordCounts = $wordCounts | append $entry }}
+  {{ if gt $entry.count 0 }}
+    {{ $wordCounts = $wordCounts | append $entry }}
+  {{ end }}
 {{ end }}
 
-{{ return (dict "wordCounts" $wordCounts "counts" (dict "openers" (len $openerSet) "nonOpeners" (len $nonOpenerSet) "total" (len $wordCounts))) }}
+{{ return $wordCounts }}


### PR DESCRIPTION
## Summary
- compute non-opener word usage directly in Hugo
- list distinct opener and non-opener counts with a full usage report
- show a top 10 non-opener table on the index page

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68bcfb89d4f88323b634299d555df764