### PR TITLE
Fix shift and middlers for 2025-03-31 puzzle

### DIFF
--- a/content/w/2025-03-31/index.md
+++ b/content/w/2025-03-31/index.md
@@ -6,10 +6,10 @@ git_branch: 2025-03-31_1381
 contests: []
 words: ["focus","doily","wonky","ropey","boogy","boozy"]
 openers: ["focus"]
-middlers: ["doily","wonky","ropey","boogy"]
+middlers: ["doily","wonky","ropey","boogy","boozy"]
 puzzles: [1381]
 hashes: ["ACAAAACAACACAACACAACCCCACCCCAC"]
-shifts: ["hvwii"]
+shifts: ["hvwci"]
 state: {
   "puzzleDate": "2025-03-31",
   "boardState": [


### PR DESCRIPTION
## Summary
- Include final guess in middlers for failed 2025-03-31 puzzle
- Ensure shift code encodes the solution "booty"

## Testing
- `python - <<'PY'` verifying openers, middlers, shift, hash, and day offset

------
https://chatgpt.com/codex/tasks/task_e_68bd97df0b948323aee6e3e11b769ffa