### PR TITLE
fix solution and shift for 2025-05-13 puzzle

### DIFF
--- a/content/w/2025-05-13/index.md
+++ b/content/w/2025-05-13/index.md
@@ -6,10 +6,10 @@ git_branch: 2025-05-13_1424
 contests: []
 words: ["guide","stoke","flame","crane","brave","heare"]
 openers: ["guide"]
-middlers: ["stoke","flame","crane","brave"]
+middlers: ["stoke","flame","crane","brave","heare"]
 puzzles: [1424]
 hashes: ["AAAACAAAACAACACAPCACAPCACAACCC"]
-shifts: ["nliao"]
+shifts: ["gdiao"]
 state: {
   "puzzleDate": "2025-05-13",
   "boardState": [
@@ -65,7 +65,7 @@ state: {
     ]
   ],
   "rowIndex": 6,
-  "solution": "heare",
+  "solution": "aware",
   "gameStatus": "FAIL",
   "hardMode": true,
   "gameId": "1173",


### PR DESCRIPTION
## Summary
- correct solution for May 13, 2025 puzzle
- regenerate shift string to match corrected solution
- include failed final guess in middlers list

## Testing
- `node - <<'NODE' ...` (puzzle hash matches and shift decodes to solution)
- `npx zx content/r/guess-words.md` *(fails: 403 Forbidden from registry.npmjs.org)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd97ccc4708323863bf456fdca23c9