### PR TITLE
Add workflow to run Rules scripts on PRs

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -1,0 +1,25 @@
+name: Run Rules Scripts
+
+on:
+  pull_request:
+
+jobs:
+  run-rules:
+    name: Run Rules
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - name: Install zx
+        run: npm install -g zx
+      - name: Run rule scripts on puzzles
+        run: |
+          set -o pipefail
+          for script in content/r/*.md; do
+            if [[ "$(basename "$script")" != "_index.md" ]]; then
+              echo "Running $script"
+              find content/w -name "*.md" | grep -v "_index" | xargs -I {} sh -c "cat {} | zx $script"
+            fi
+          done

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,6 +5,7 @@ pull_request_rules:
       - base=main
       - label=puzzle
       - check-success=Cloudflare Pages
+      - check-success=Run Rules
     actions:
       merge:
         method: squash


### PR DESCRIPTION
## Summary
- add workflow to execute Rule scripts against all puzzles
- block mergify until Rules check passes

## Testing
- `npx zx content/r/guess-count.md` *(fails: 403 Forbidden - GET https://registry.npmjs.org/zx)*

------
https://chatgpt.com/codex/tasks/task_e_68befd3ec29083238b37c9e8c13167a5