### PR TITLE
Add Wordle puzzle for 2024-04-30

### DIFF
--- a/content/w/2024-04-30/index.md
+++ b/content/w/2024-04-30/index.md
@@ -1,0 +1,104 @@
+---
+title: "1046: 2024-04-30"
+date: 2024-04-30T09:00:00-07:00
+tags: []
+git_branch: 2024-04-30_1046
+contests: []
+words: ["style","blank","lurch","drool","growl","prowl"]
+openers: ["style"]
+middlers: ["blank","lurch","drool","growl"]
+puzzles: [1046]
+hashes: ["AAAPAAPAAAPAPAAACCACACCCCCCCCC"]
+shifts: ["vywfv"]
+state: {
+  "boardState": [
+    "style",
+    "blank",
+    "lurch",
+    "drool",
+    "growl",
+    "prowl"
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "absent",
+      "absent",
+      "present",
+      "absent"
+    ],
+    [
+      "absent",
+      "present",
+      "absent",
+      "absent",
+      "absent"
+    ],
+    [
+      "present",
+      "absent",
+      "present",
+      "absent",
+      "absent"
+    ],
+    [
+      "absent",
+      "correct",
+      "correct",
+      "absent",
+      "correct"
+    ],
+    [
+      "absent",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ]
+  ],
+  "rowIndex": 6,
+  "solution": "prowl",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1714492039866,
+  "lastCompletedTs": 1714492039866,
+  "hardMode": true,
+  "settings": {
+    "schemaVersion": "0.16.0",
+    "timestamp": 1711377281,
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 2035,
+  "dayOffset": 1046,
+  "timestamp": 1714492039
+}
+stats: {
+  "gamesPlayed": 259,
+  "gamesWon": 257,
+  "guesses": {
+    "1": 0,
+    "2": 12,
+    "3": 62,
+    "4": 104,
+    "5": 48,
+    "6": 31,
+    "fail": 2
+  },
+  "currentStreak": 9,
+  "maxStreak": 36,
+  "hasPlayed": true,
+  "lastWonDayOffset": 1046,
+  "timestamp": 1714405639,
+  "averageGuesses": 4,
+  "winPercentage": 99
+}
+---
+<!-- more -->


### PR DESCRIPTION
## Summary
- add puzzle entry for April 30, 2024 with full game state and stats

## Testing
- `hugo --templateMetrics`

------
https://chatgpt.com/codex/tasks/task_e_68c2449855288323b003c57121fdbbf4