### PR TITLE
Add May 1 2024 Wordle puzzle

### DIFF
--- a/content/w/2024-05-01/index.md
+++ b/content/w/2024-05-01/index.md
@@ -1,0 +1,78 @@
+---
+title: "1047: 2024-05-01"
+date: 2024-05-01T10:32:12-07:00
+tags: []
+git_branch: 2024-05-01_1047
+contests: []
+words: ["style","crazy","diary"]
+openers: ["style"]
+middlers: ["crazy"]
+puzzles: [1047]
+hashes: ["AAPAAAPCACCCCCCXXXXXXXXXXXXXXX"]
+shifts: ["jpiai"]
+state: {
+  "puzzleDate": "2024-05-01",
+  "boardState": [
+    "style",
+    "crazy",
+    "diary",
+    "",
+    "",
+    ""
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "absent",
+      "present",
+      "absent",
+      "absent"
+    ],
+    [
+      "absent",
+      "present",
+      "correct",
+      "absent",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null,
+    null,
+    null
+  ],
+  "rowIndex": 3,
+  "solution": "diary",
+  "gameStatus": "WIN",
+  "hardMode": true,
+  "gameId": "1047",
+  "dayOffset": 1047,
+  "timestamp": 1714584732,
+  "datetime": "2024-05-01T10:32:12",
+  "schemaVersion": "0.16.0"
+}
+stats: {
+  "gamesPlayed": 259,
+  "gamesWon": 257,
+  "guesses": {
+    "1": 0,
+    "2": 12,
+    "3": 63,
+    "4": 104,
+    "5": 48,
+    "6": 30,
+    "fail": 2
+  },
+  "currentStreak": 1,
+  "maxStreak": 36,
+  "hasPlayed": true,
+  "lastWonDayOffset": 1047,
+  "timestamp": 1714584732
+}
+---
+<!-- more -->


### PR DESCRIPTION
## Summary
- add metadata for the May 1, 2024 Wordle puzzle solved with STYLE → CRAZY → DIARY

## Testing
- `cat content/w/2024-05-01/index.md | npx zx content/r/guess-count.md` *(fails: 403 Forbidden - GET https://registry.npmjs.org/zx)*

------
https://chatgpt.com/codex/tasks/task_e_68c2474173208323bbfe14bb8a52bc5a