### PR TITLE
feat: add Wordle 1048 puzzle

### DIFF
--- a/content/w/2024-05-02/index.md
+++ b/content/w/2024-05-02/index.md
@@ -1,0 +1,90 @@
+---
+title: "1048: 2024-05-02"
+date: 2024-05-02T06:46:00-07:00
+tags: []
+git_branch: 2024-05-02_1048
+contests: []
+words: ["style","slope","slime","slide","slice"]
+openers: ["style"]
+middlers: ["slope","slime","slide"]
+puzzles: [1048]
+hashes: ["CAAPCCCAACCCCACCCCACCCCCCXXXXX"]
+shifts: ["ysqlo"]
+state: {
+  "puzzleDate": "2024-05-02",
+  "boardState": [
+    "style",
+    "slope",
+    "slime",
+    "slide",
+    "slice",
+    ""
+  ],
+  "evaluations": [
+    [
+      "correct",
+      "absent",
+      "absent",
+      "present",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "absent",
+      "absent",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "absent",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "absent",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null
+  ],
+  "rowIndex": 5,
+  "solution": "slice",
+  "gameStatus": "WIN",
+  "hardMode": true,
+  "gameId": "1048",
+  "dayOffset": 1048,
+  "timestamp": 1714657560,
+  "datetime": "2024-05-02T06:46:00",
+  "schemaVersion": "0.16.0"
+}
+stats: {
+  "gamesPlayed": 260,
+  "gamesWon": 258,
+  "guesses": {
+    "1": 0,
+    "2": 12,
+    "3": 63,
+    "4": 104,
+    "5": 49,
+    "6": 30,
+    "fail": 2
+  },
+  "currentStreak": 2,
+  "maxStreak": 36,
+  "hasPlayed": true,
+  "lastWonDayOffset": 1048,
+  "timestamp": 1714657560
+}
+---
+<!-- more -->


### PR DESCRIPTION
## Summary
- add puzzle entry for Wordle 1048 on 2024-05-02

## Testing
- `hugo -s .`

------
https://chatgpt.com/codex/tasks/task_e_68c396c47ad883239167f78d8fbbc641