### PR TITLE
Add Wordle puzzle 1050

### DIFF
--- a/content/w/2024-05-04/index.md
+++ b/content/w/2024-05-04/index.md
@@ -1,0 +1,90 @@
+---
+title: "1050: 2024-05-04"
+date: 2024-05-04T12:32:00-07:00
+tags: []
+git_branch: 2024-05-04_1050
+contests: []
+words: ["style","glare","lance","valve","value"]
+openers: ["style"]
+middlers: ["glare","lance","valve"]
+puzzles: [1050]
+hashes: ["AAAPCAPPACPCAACCCCACCCCCCXXXXX"]
+shifts: ["bhtdo"]
+state: {
+  "puzzleDate": "2024-05-04",
+  "boardState": [
+    "style",
+    "glare",
+    "lance",
+    "valve",
+    "value",
+    ""
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "absent",
+      "absent",
+      "present",
+      "correct"
+    ],
+    [
+      "absent",
+      "present",
+      "present",
+      "absent",
+      "correct"
+    ],
+    [
+      "present",
+      "correct",
+      "absent",
+      "absent",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "absent",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null
+  ],
+  "rowIndex": 5,
+  "solution": "value",
+  "gameStatus": "WIN",
+  "hardMode": true,
+  "gameId": "1050",
+  "dayOffset": 1050,
+  "timestamp": 1714851120,
+  "datetime": "2024-05-04T12:32:00",
+  "schemaVersion": "0.16.0"
+}
+stats: {
+  "gamesPlayed": 260,
+  "gamesWon": 258,
+  "guesses": {
+    "1": 0,
+    "2": 12,
+    "3": 63,
+    "4": 104,
+    "5": 48,
+    "6": 31,
+    "fail": 2
+  },
+  "currentStreak": 1,
+  "maxStreak": 36,
+  "hasPlayed": true,
+  "lastWonDayOffset": 1050,
+  "timestamp": 1714851120
+}
+---
+<!-- more -->


### PR DESCRIPTION
## Summary
- add missing entry for Wordle 1050 (2024-05-04) with guess details and metadata

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68c3974930a883238e6bca0460566c6f