### PR TITLE
Add index.md for 2024-06-16 Wordle puzzle

### DIFF
--- a/content/w/2024-06-16/index.md
+++ b/content/w/2024-06-16/index.md
@@ -1,0 +1,78 @@
+---
+title: "1093: 2024-06-16"
+date: 2024-06-16T07:01:00-07:00
+tags: []
+git_branch: 2024-06-16_1093
+contests: []
+words: ["straw","reign","grind"]
+openers: ["straw"]
+middlers: ["reign"]
+puzzles: [1093]
+hashes: ["AAPAAPACPPCCCCCXXXXXXXXXXXXXXX"]
+shifts: ["myqwn"]
+state: {
+  "puzzleDate": "2024-06-16",
+  "boardState": [
+    "straw",
+    "reign",
+    "grind",
+    "",
+    "",
+    ""
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "absent",
+      "present",
+      "absent",
+      "absent"
+    ],
+    [
+      "present",
+      "absent",
+      "correct",
+      "present",
+      "present"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null,
+    null,
+    null
+  ],
+  "rowIndex": 3,
+  "solution": "grind",
+  "gameStatus": "WIN",
+  "hardMode": true,
+  "gameId": "1692",
+  "dayOffset": 1093,
+  "timestamp": 1718546460,
+  "datetime": "2024-06-16T07:01:00",
+  "schemaVersion": "0.20.0"
+}
+stats: {
+  "gamesPlayed": 299,
+  "gamesWon": 294,
+  "guesses": {
+    "1": 0,
+    "2": 12,
+    "3": 72,
+    "4": 122,
+    "5": 55,
+    "6": 33,
+    "fail": 5
+  },
+  "currentStreak": 8,
+  "maxStreak": 36,
+  "hasPlayed": true,
+  "lastWonDayOffset": 1093,
+  "timestamp": 1718546460
+}
+---
+<!-- more -->


### PR DESCRIPTION
## Summary
- add puzzle details for 2024-06-16 (#1093)

## Testing
- `npm test` *(fails: Could not read package.json)*
- `hugo version`


------
https://chatgpt.com/codex/tasks/task_e_68c397a9bf608323bcc9a7d728c0c3ab