### PR TITLE
Add June 17, 2024 Wordle puzzle

### DIFF
--- a/content/w/2024-06-17/index.md
+++ b/content/w/2024-06-17/index.md
@@ -1,0 +1,78 @@
+---
+title: "1094: 2024-06-17"
+date: 2024-06-17T06:30:00-07:00
+tags: []
+git_branch: 2024-06-17_1094
+contests: []
+words: ["brown","credo","prior"]
+openers: ["brown"]
+middlers: ["credo"]
+puzzles: [1094]
+hashes: ["ACPAAACAAPCCCCCXXXXXXXXXXXXXXX"]
+shifts: ["vyqxb"]
+state: {
+  "puzzleDate": "2024-06-17",
+  "boardState": [
+    "brown",
+    "credo",
+    "prior",
+    "",
+    "",
+    ""
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "correct",
+      "present",
+      "absent",
+      "absent"
+    ],
+    [
+      "absent",
+      "correct",
+      "absent",
+      "absent",
+      "present"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null,
+    null,
+    null
+  ],
+  "rowIndex": 3,
+  "solution": "prior",
+  "gameStatus": "WIN",
+  "hardMode": true,
+  "gameId": "0",
+  "dayOffset": 1094,
+  "timestamp": 1718631000,
+  "datetime": "2024-06-17T06:30:00",
+  "schemaVersion": "0.20.0"
+}
+stats: {
+  "gamesPlayed": 299,
+  "gamesWon": 294,
+  "guesses": {
+    "1": 0,
+    "2": 12,
+    "3": 72,
+    "4": 122,
+    "5": 55,
+    "6": 33,
+    "fail": 5
+  },
+  "currentStreak": 1,
+  "maxStreak": 36,
+  "hasPlayed": true,
+  "lastWonDayOffset": 1094,
+  "timestamp": 1718631000
+}
+---
+<!-- more -->


### PR DESCRIPTION
## Summary
- add missing Wordle puzzle for June 17, 2024

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68c397ca71988323becb0a288df4c9b2