### PR TITLE
Add Wordle puzzle for 2024-06-24

### DIFF
--- a/content/w/2024-06-24/index.md
+++ b/content/w/2024-06-24/index.md
@@ -1,0 +1,90 @@
+---
+title: "1101: 2024-06-24"
+date: 2024-06-24T10:22:00-07:00
+tags: []
+git_branch: 2024-06-24_1101
+contests: []
+words: ["scout","gorge","doily","dooly","dolly"]
+openers: ["scout"]
+middlers: ["gorge","doily","dooly"]
+puzzles: [1101]
+hashes: ["AAPAAACAAACCACCCCACCCCCCCXXXXX"]
+shifts: ["jvtui"]
+state: {
+  "puzzleDate": "2024-06-24",
+  "boardState": [
+    "scout",
+    "gorge",
+    "doily",
+    "dooly",
+    "dolly",
+    ""
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "absent",
+      "present",
+      "absent",
+      "absent"
+    ],
+    [
+      "absent",
+      "correct",
+      "absent",
+      "absent",
+      "absent"
+    ],
+    [
+      "correct",
+      "correct",
+      "absent",
+      "correct",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "absent",
+      "correct",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null
+  ],
+  "rowIndex": 5,
+  "solution": "dolly",
+  "gameStatus": "WIN",
+  "hardMode": true,
+  "gameId": "1790",
+  "dayOffset": 1101,
+  "timestamp": 1719249720,
+  "datetime": "2024-06-24T10:22:00",
+  "schemaVersion": "0.20.0"
+}
+stats: {
+  "gamesPlayed": 303,
+  "gamesWon": 298,
+  "guesses": {
+    "1": 0,
+    "2": 12,
+    "3": 72,
+    "4": 125,
+    "5": 56,
+    "6": 33,
+    "fail": 5
+  },
+  "currentStreak": 1,
+  "maxStreak": 36,
+  "hasPlayed": true,
+  "lastWonDayOffset": 1101,
+  "timestamp": 1719249720
+}
+---
+<!-- more -->


### PR DESCRIPTION
## Summary
- add missing puzzle for June 24, 2024 with solution "dolly"

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_68c398109b8883239530abaf9fe1e908