### PR TITLE
Add missing puzzle for 2024-03-11

### DIFF
--- a/content/w/2024-03-11/index.md
+++ b/content/w/2024-03-11/index.md
@@ -1,0 +1,96 @@
+---
+title: "996: 2024-03-11"
+date: 2024-03-11T07:07:00-07:00
+tags: []
+git_branch: 2024-03-11_996
+contests: []
+words: ["syrup","psych","pansy","posey","pesky"]
+openers: ["syrup"]
+middlers: ["psych","pansy","posey"]
+puzzles: [996]
+hashes: ["PPAAPCPPAACAAPCCACPCCCCCCXXXXX"]
+shifts: ["vlati"]
+state: {
+  "boardState": [
+    "syrup",
+    "psych",
+    "pansy",
+    "posey",
+    "pesky",
+    ""
+  ],
+  "evaluations": [
+    [
+      "present",
+      "present",
+      "absent",
+      "absent",
+      "present"
+    ],
+    [
+      "correct",
+      "present",
+      "present",
+      "absent",
+      "absent"
+    ],
+    [
+      "correct",
+      "absent",
+      "absent",
+      "present",
+      "correct"
+    ],
+    [
+      "correct",
+      "absent",
+      "correct",
+      "present",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null
+  ],
+  "rowIndex": 5,
+  "solution": "pesky",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1710166020000,
+  "lastCompletedTs": 1710166020000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 1784,
+  "dayOffset": 996,
+  "timestamp": 1710166020
+}
+stats: {
+  "currentStreak": 8,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 11,
+    "3": 51,
+    "4": 85,
+    "5": 44,
+    "6": 23,
+    "fail": 1
+  },
+  "winPercentage": 100,
+  "gamesPlayed": 215,
+  "gamesWon": 214,
+  "averageGuesses": 4,
+  "isOnStreak": true,
+  "hasPlayed": true,
+  "lastWonDayOffset": 996
+}
+---
+<!-- more -->


### PR DESCRIPTION
## Summary
- add puzzle entry for 2024-03-11 (Wordle 996) solved with PESKY

## Testing
- `node static/tools/enhance/enrich-emoji.test.js`
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68c41c422a948323a0a4c48b22e9336b