### PR TITLE
Add March 3 2024 puzzle

### DIFF
--- a/content/w/2024-03-03/index.md
+++ b/content/w/2024-03-03/index.md
@@ -1,0 +1,66 @@
+---
+title: "988: 2024-03-03"
+date: 2024-03-03T08:25:00-08:00
+tags: []
+git_branch: 2024-03-03_988
+contests: []
+words: ["radio","shake","slate","spate","state"]
+openers: ["radio"]
+middlers: ["shake","slate","spate"]
+puzzles: [988]
+hashes: ["APAAACACACCACCCCACCCCCCCCXXXXX"]
+shifts: ["yaico"]
+state: {
+  "boardState": [
+    "radio",
+    "shake",
+    "slate",
+    "spate",
+    "state",
+    ""
+  ],
+  "evaluations": [
+    ["absent","present","absent","absent","absent"],
+    ["correct","absent","correct","absent","correct"],
+    ["correct","absent","correct","correct","correct"],
+    ["correct","absent","correct","correct","correct"],
+    ["correct","correct","correct","correct","correct"],
+    null
+  ],
+  "rowIndex": 5,
+  "solution": "state",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1709483100000,
+  "lastCompletedTs": 1709483100000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 1777,
+  "dayOffset": 988,
+  "timestamp": 1709483100
+}
+stats: {
+  "currentStreak": 26,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 11,
+    "3": 49,
+    "4": 81,
+    "5": 43,
+    "6": 23,
+    "fail": 1
+  },
+  "winPercentage": 100,
+  "gamesPlayed": 208,
+  "gamesWon": 207,
+  "averageGuesses": 4,
+  "isOnStreak": true,
+  "hasPlayed": true,
+  "lastWonDayOffset": 988
+}
+---
+<!-- more -->


### PR DESCRIPTION
## Summary
- add March 3 2024 Wordle puzzle data (solution: STATE) with guesses and stats

## Testing
- `hugo --destination /tmp/public`

------
https://chatgpt.com/codex/tasks/task_e_68c41c75bfa8832393d1613d0df07c7e