### PR TITLE
Add puzzle for 2023-09-20

### DIFF
--- a/content/w/2023-09-20/index.md
+++ b/content/w/2023-09-20/index.md
@@ -1,0 +1,77 @@
+---
+title: "823: 2023-09-20"
+date: 2023-09-20T02:41:00-07:00
+tags: []
+git_branch: 2023-09-20_823
+contests: []
+words: ["ocean","snare"]
+openers: ["ocean"]
+middlers: []
+puzzles: [823]
+hashes: ["AAPPPCCCCCXXXXXXXXXXXXXXXXXXXX"]
+shifts: ["gkqtp"]
+state: {
+  "boardState": [
+    "ocean",
+    "snare",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "absent",
+      "present",
+      "present",
+      "present"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null,
+    null,
+    null,
+    null
+  ],
+  "rowIndex": 2,
+  "solution": "snare",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1695202860000,
+  "lastCompletedTs": 1695202860000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 696,
+  "dayOffset": 823,
+  "timestamp": 1695202860
+}
+stats: {
+  "currentStreak": 11,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 2,
+    "3": 15,
+    "4": 26,
+    "5": 13,
+    "6": 8,
+    "fail": 0
+  },
+  "winPercentage": 100,
+  "gamesPlayed": 64,
+  "gamesWon": 64,
+  "averageGuesses": 4,
+  "isOnStreak": true,
+  "hasPlayed": true
+}
+---
+<!-- more -->


### PR DESCRIPTION
## Summary
- add missing Wordle puzzle #823 for 2023-09-20

## Testing
- `npm test` *(fails: Could not read package.json)*
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_68c41ced950c83239cc92f8a7e5060ee