### PR TITLE
Add Wordle puzzle for 2023-10-18

### DIFF
--- a/content/w/2023-10-18/index.md
+++ b/content/w/2023-10-18/index.md
@@ -1,0 +1,89 @@
+---
+title: "851: 2023-10-18"
+date: 2023-10-18T08:59:00-07:00
+tags: []
+git_branch: 2023-10-18_851
+contests: []
+words: ["ounce","check","react","mercy"]
+openers: ["ounce"]
+middlers: ["check","react"]
+puzzles: [851]
+hashes: ["AAACPPAPCAPCACACCCCCXXXXXXXXXX"]
+shifts: ["slzli"]
+state: {
+  "boardState": [
+    "ounce",
+    "check",
+    "react",
+    "mercy",
+    "",
+    ""
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "absent",
+      "absent",
+      "correct",
+      "present"
+    ],
+    [
+      "present",
+      "absent",
+      "present",
+      "correct",
+      "absent"
+    ],
+    [
+      "present",
+      "correct",
+      "absent",
+      "correct",
+      "absent"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null,
+    null
+  ],
+  "rowIndex": 4,
+  "solution": "mercy",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1697644740000,
+  "lastCompletedTs": 1697644740000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 2267,
+  "dayOffset": 851,
+  "timestamp": 1697644740
+}
+stats: {
+  "currentStreak": 8,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 3,
+    "3": 19,
+    "4": 37,
+    "5": 17,
+    "6": 13,
+    "fail": 0
+  },
+  "winPercentage": 100,
+  "gamesPlayed": 89,
+  "gamesWon": 89,
+  "averageGuesses": 4,
+  "isOnStreak": true,
+  "hasPlayed": true
+}
+---
+<!-- more -->


### PR DESCRIPTION
## Summary
- add puzzle entry for October 18, 2023 (solution: MERCY)

## Testing
- `hugo --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68c5096c6f908323ba0feb83c08d5fb6