### PR TITLE
Add Wordle entry for October 19, 2023

### DIFF
--- a/content/w/2023-10-19/index.md
+++ b/content/w/2023-10-19/index.md
@@ -1,0 +1,89 @@
+---
+title: "852: 2023-10-19"
+date: 2023-10-19T11:41:00-07:00
+tags: []
+git_branch: 2023-10-19_852
+contests: []
+words: ["ounce","slimy","shalt","splat"]
+openers: ["ounce"]
+middlers: ["slimy","shalt"]
+puzzles: [852]
+hashes: ["AAAAACPAAACAPPCCCCCCXXXXXXXXXX"]
+shifts: ["ywtjd"]
+state: {
+  "boardState": [
+    "ounce",
+    "slimy",
+    "shalt",
+    "splat",
+    "",
+    ""
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "absent",
+      "absent",
+      "absent",
+      "absent"
+    ],
+    [
+      "correct",
+      "present",
+      "absent",
+      "absent",
+      "absent"
+    ],
+    [
+      "correct",
+      "absent",
+      "present",
+      "present",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null,
+    null
+  ],
+  "rowIndex": 4,
+  "solution": "splat",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1697740860000,
+  "lastCompletedTs": 1697740860000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 0,
+  "dayOffset": 852,
+  "timestamp": 1697740860
+}
+stats: {
+  "currentStreak": 8,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 3,
+    "3": 19,
+    "4": 37,
+    "5": 17,
+    "6": 13,
+    "fail": 0
+  },
+  "winPercentage": 100,
+  "gamesPlayed": 89,
+  "gamesWon": 89,
+  "averageGuesses": 4,
+  "isOnStreak": true,
+  "hasPlayed": true
+}
+---
+<!-- more -->


### PR DESCRIPTION
## Summary
- log Wordle puzzle 852 played on 2023-10-19 with guesses and result metadata

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68c509a9dc808323928fbe818c3da590