### PR TITLE
Add Wordle puzzle for 2023-10-20

### DIFF
--- a/content/w/2023-10-20/index.md
+++ b/content/w/2023-10-20/index.md
@@ -1,0 +1,77 @@
+---
+title: "853: 2023-10-20"
+date: 2023-10-20T13:11:00-07:00
+tags: []
+git_branch: 2023-10-20_853
+contests: []
+words: ["ounce","occur"]
+openers: ["ounce"]
+middlers: []
+puzzles: [853]
+hashes: ["CPAPACCCCCXXXXXXXXXXXXXXXXXXXX"]
+shifts: ["ujkdb"]
+state: {
+  "boardState": [
+    "ounce",
+    "occur",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "evaluations": [
+    [
+      "correct",
+      "present",
+      "absent",
+      "present",
+      "absent"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null,
+    null,
+    null,
+    null
+  ],
+  "rowIndex": 2,
+  "solution": "occur",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1697832660000,
+  "lastCompletedTs": 1697832660000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 0,
+  "dayOffset": 853,
+  "timestamp": 1697832660
+}
+stats: {
+  "currentStreak": 1,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 4,
+    "3": 19,
+    "4": 36,
+    "5": 17,
+    "6": 13,
+    "fail": 0
+  },
+  "winPercentage": 100,
+  "gamesPlayed": 89,
+  "gamesWon": 89,
+  "averageGuesses": 4,
+  "isOnStreak": false,
+  "hasPlayed": true
+}
+---
+<!-- more -->


### PR DESCRIPTION
## Summary
- add October 20, 2023 Wordle entry with solution "occur"

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_68c509d09ef88323b989222f1583b91b