### PR TITLE
Add Oct 21 2023 Wordle puzzle

### DIFF
--- a/content/w/2023-10-21/index.md
+++ b/content/w/2023-10-21/index.md
@@ -1,0 +1,89 @@
+---
+title: "854: 2023-10-21"
+date: 2023-10-21T16:19:00-07:00
+tags: []
+git_branch: 2023-10-21_854
+contests: []
+words: ["ounce","strap","shirk","smirk"]
+openers: ["ounce"]
+middlers: ["strap","shirk"]
+puzzles: [854]
+hashes: ["AAAAACAPAACACCCCCCCCXXXXXXXXXX"]
+shifts: ["ytqau"]
+state: {
+  "boardState": [
+    "ounce",
+    "strap",
+    "shirk",
+    "smirk",
+    "",
+    ""
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "absent",
+      "absent",
+      "absent",
+      "absent"
+    ],
+    [
+      "correct",
+      "absent",
+      "present",
+      "absent",
+      "absent"
+    ],
+    [
+      "correct",
+      "absent",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null,
+    null
+  ],
+  "rowIndex": 4,
+  "solution": "smirk",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1697930340000,
+  "lastCompletedTs": 1697930340000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 1212,
+  "dayOffset": 854,
+  "timestamp": 1697930340
+}
+stats: {
+  "currentStreak": 36,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 3,
+    "3": 19,
+    "4": 35,
+    "5": 17,
+    "6": 13,
+    "fail": 0
+  },
+  "winPercentage": 100,
+  "gamesPlayed": 87,
+  "gamesWon": 87,
+  "averageGuesses": 4,
+  "isOnStreak": true,
+  "hasPlayed": true
+}
+---
+<!-- more -->


### PR DESCRIPTION
## Summary
- record Wordle 854 from 2023-10-21 with guess sequence OUNCE→STRAP→SHIRK→SMIRK

## Testing
- `node static/tools/enhance/enrich-emoji.test.js`
- `cat content/w/2023-10-21/index.md | npx zx content/r/guess-count.md` *(fails: 403 Forbidden - GET https://registry.npmjs.org/zx)*
- `cat content/w/2023-10-21/index.md | npx zx content/r/guess-words.md` *(fails: 403 Forbidden - GET https://registry.npmjs.org/zx)*
- `cat content/w/2023-10-21/index.md | npx zx content/r/outcome.md` *(fails: 403 Forbidden - GET https://registry.npmjs.org/zx)*

------
https://chatgpt.com/codex/tasks/task_e_68c509ffb43883238eb634b2cde82453