### PR TITLE
add puzzle for 2023-11-09

### DIFF
--- a/content/w/2023-11-09/index.md
+++ b/content/w/2023-11-09/index.md
@@ -1,0 +1,95 @@
+---
+title: "873: 2023-11-09"
+date: 2023-11-09T05:23:00-08:00
+tags: []
+git_branch: 2023-11-09_873
+contests: []
+words: ["ounce","style","ledge","glare","glaze"]
+openers: ["ounce"]
+middlers: ["style","ledge","glare"]
+puzzles: [873]
+hashes: ["AAAACAAAPCPAAPCCCCACCCCCCXXXXX"]
+shifts: ["msiio"]
+state: {
+  "boardState": [
+    "ounce",
+    "style",
+    "ledge",
+    "glare",
+    "glaze",
+    ""
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "absent",
+      "absent",
+      "absent",
+      "correct"
+    ],
+    [
+      "absent",
+      "absent",
+      "absent",
+      "present",
+      "correct"
+    ],
+    [
+      "present",
+      "absent",
+      "absent",
+      "present",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "absent",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null
+  ],
+  "rowIndex": 5,
+  "solution": "glaze",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1699536180000,
+  "lastCompletedTs": 1699536180000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 2072,
+  "dayOffset": 873,
+  "timestamp": 1699536180
+}
+stats: {
+  "currentStreak": 18,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 4,
+    "3": 23,
+    "4": 45,
+    "5": 20,
+    "6": 14,
+    "fail": 0
+  },
+  "winPercentage": 100,
+  "gamesPlayed": 106,
+  "gamesWon": 106,
+  "averageGuesses": 4,
+  "isOnStreak": true,
+  "hasPlayed": true
+}
+---
+<!-- more -->


### PR DESCRIPTION
## Summary
- add missing Wordle puzzle for 2023-11-09 with solution "glaze"

## Testing
- `npm test` *(fails: Could not read package.json)*
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68c50a98eb648323aa9a72e3aec4ee7b