### PR TITLE
Add Wordle puzzle for 2023-11-13

### DIFF
--- a/content/w/2023-11-13/index.md
+++ b/content/w/2023-11-13/index.md
@@ -1,0 +1,95 @@
+---
+title: "877: 2023-11-13"
+date: 2023-11-13T06:27:00-08:00
+tags: []
+git_branch: 2023-11-13_877
+contests: []
+words: ["ounce","entry","never","preen","green"]
+openers: ["ounce"]
+middlers: ["entry","never","preen"]
+puzzles: [877]
+hashes: ["AAPAPPPAPAPPACPACCCCCCCCCXXXXX"]
+shifts: ["bktxz"]
+state: {
+  "boardState": [
+    "ounce",
+    "entry",
+    "never",
+    "preen",
+    "green",
+    ""
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "absent",
+      "present",
+      "absent",
+      "present"
+    ],
+    [
+      "present",
+      "present",
+      "absent",
+      "present",
+      "absent"
+    ],
+    [
+      "present",
+      "present",
+      "absent",
+      "correct",
+      "present"
+    ],
+    [
+      "absent",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null
+  ],
+  "rowIndex": 5,
+  "solution": "green",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1699885620000,
+  "lastCompletedTs": 1699885620000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 907,
+  "dayOffset": 877,
+  "timestamp": 1699885620
+}
+stats: {
+  "currentStreak": 2,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 4,
+    "3": 23,
+    "4": 47,
+    "5": 20,
+    "6": 14,
+    "fail": 0
+  },
+  "winPercentage": 100,
+  "gamesPlayed": 108,
+  "gamesWon": 108,
+  "averageGuesses": 4,
+  "isOnStreak": true,
+  "hasPlayed": true
+}
+---
+<!-- more -->


### PR DESCRIPTION
## Summary
- add entry for the November 13, 2023 puzzle solved in five guesses

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68c50b0b80a083239b020fd7dda6c3b8