### PR TITLE
Add 2023-11-14 Wordle puzzle

### DIFF
--- a/content/w/2023-11-14/index.md
+++ b/content/w/2023-11-14/index.md
@@ -1,0 +1,102 @@
+---
+title: "878: 2023-11-14"
+date: 2023-11-14T05:57:00-08:00
+tags: []
+git_branch: 2023-11-14_878
+contests: []
+words: ["ounce","flair","pasta","washy","gassy","sassy"]
+openers: ["ounce"]
+middlers: ["flair","pasta","washy","gassy"]
+puzzles: [878]
+hashes: ["AAAAAAAPAAACCAAACCACACCCCCCCCC"]
+shifts: ["yhabi"]
+state: {
+  "boardState": [
+    "ounce",
+    "flair",
+    "pasta",
+    "washy",
+    "gassy",
+    "sassy"
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "absent",
+      "absent",
+      "absent",
+      "absent"
+    ],
+    [
+      "absent",
+      "absent",
+      "present",
+      "absent",
+      "absent"
+    ],
+    [
+      "absent",
+      "correct",
+      "correct",
+      "absent",
+      "absent"
+    ],
+    [
+      "absent",
+      "correct",
+      "correct",
+      "absent",
+      "correct"
+    ],
+    [
+      "absent",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ]
+  ],
+  "rowIndex": 6,
+  "solution": "sassy",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1699970220000,
+  "lastCompletedTs": 1699970220000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 2001,
+  "dayOffset": 878,
+  "timestamp": 1699970220
+}
+stats: {
+  "currentStreak": 1,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 4,
+    "3": 23,
+    "4": 47,
+    "5": 19,
+    "6": 15,
+    "fail": 0
+  },
+  "winPercentage": 100,
+  "gamesPlayed": 108,
+  "gamesWon": 108,
+  "averageGuesses": 4,
+  "isOnStreak": false,
+  "hasPlayed": true
+}
+---
+<!-- more -->
+Needed all six attempts to nail the solution.


### PR DESCRIPTION
## Summary
- add puzzle entry for Nov 14, 2023 with solution "sassy"

## Testing
- `hugo -v`


------
https://chatgpt.com/codex/tasks/task_e_68c50b3c704083238ac820e4a32732f5