### PR TITLE
Add 2023-11-15 Wordle puzzle entry

### DIFF
--- a/content/w/2023-11-15/index.md
+++ b/content/w/2023-11-15/index.md
@@ -1,0 +1,95 @@
+---
+title: "879: 2023-11-15"
+date: 2023-11-15T15:18:00-08:00
+tags: []
+git_branch: 2023-11-15_879
+contests: []
+words: ["ounce","party","still","sixty","sixth"]
+openers: ["ounce"]
+middlers: ["party","still","sixty"]
+puzzles: [879]
+hashes: ["AAAAAAAACACPPAACCCCACCCCCXXXXX"]
+shifts: ["ypfcr"]
+state: {
+  "boardState": [
+    "ounce",
+    "party",
+    "still",
+    "sixty",
+    "sixth",
+    ""
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "absent",
+      "absent",
+      "absent",
+      "absent"
+    ],
+    [
+      "absent",
+      "absent",
+      "absent",
+      "correct",
+      "absent"
+    ],
+    [
+      "correct",
+      "present",
+      "present",
+      "absent",
+      "absent"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "absent"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null
+  ],
+  "rowIndex": 5,
+  "solution": "sixth",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1700090280000,
+  "lastCompletedTs": 1700090280000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 879,
+  "dayOffset": 879,
+  "timestamp": 1700090280
+}
+stats: {
+  "currentStreak": 1,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 4,
+    "3": 24,
+    "4": 47,
+    "5": 19,
+    "6": 14,
+    "fail": 0
+  },
+  "winPercentage": 100,
+  "gamesPlayed": 108,
+  "gamesWon": 108,
+  "averageGuesses": 4,
+  "isOnStreak": false,
+  "hasPlayed": true
+}
+---
+<!-- more -->


### PR DESCRIPTION
## Summary
- record Nov 15 2023 Wordle puzzle with guesses and solution

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_68c50b7e5b1083239ba3daf1b753af4d