### PR TITLE
Add Wordle puzzle for 2023-11-22

### DIFF
--- a/content/w/2023-11-22/index.md
+++ b/content/w/2023-11-22/index.md
@@ -1,0 +1,95 @@
+---
+title: "886: 2023-11-22"
+date: 2023-11-22T06:55:00-08:00
+tags: []
+git_branch: 2023-11-22_886
+contests: []
+words: ["ounce","break","jetty","plied","pixel"]
+openers: ["ounce"]
+middlers: ["break","jetty","plied"]
+puzzles: [886]
+hashes: ["AAAAPAAPAAAPAAACPPCACCCCCXXXXX"]
+shifts: ["vpfnv"]
+state: {
+  "boardState": [
+    "ounce",
+    "break",
+    "jetty",
+    "plied",
+    "pixel",
+    ""
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "absent",
+      "absent",
+      "absent",
+      "present"
+    ],
+    [
+      "absent",
+      "absent",
+      "present",
+      "absent",
+      "absent"
+    ],
+    [
+      "absent",
+      "present",
+      "absent",
+      "absent",
+      "absent"
+    ],
+    [
+      "correct",
+      "present",
+      "present",
+      "correct",
+      "absent"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null
+  ],
+  "rowIndex": 5,
+  "solution": "pixel",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1700664900000,
+  "lastCompletedTs": 1700664900000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 1216,
+  "dayOffset": 886,
+  "timestamp": 1700664900
+}
+stats: {
+  "currentStreak": 7,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 5,
+    "3": 24,
+    "4": 49,
+    "5": 21,
+    "6": 15,
+    "fail": 0
+  },
+  "winPercentage": 100,
+  "gamesPlayed": 114,
+  "gamesWon": 114,
+  "averageGuesses": 4,
+  "isOnStreak": true,
+  "hasPlayed": true
+}
+---
+<!-- more -->


### PR DESCRIPTION
## Summary
- add Wordle puzzle 886 from 2023-11-22 solved in five guesses

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_68c50c2b11cc8323bae2f597213fed07