### PR TITLE
Add Dec 29 2023 Wordle puzzle

### DIFF
--- a/content/w/2023-12-29/index.md
+++ b/content/w/2023-12-29/index.md
@@ -1,0 +1,77 @@
+---
+title: "923: 2023-12-29"
+date: 2023-12-29T06:21:00-08:00
+tags: []
+git_branch: 2023-12-29_923
+contests: []
+words: ["point","child"]
+openers: ["point"]
+middlers: []
+puzzles: [923]
+hashes: ["AACAACCCCCXXXXXXXXXXXXXXXXXXXX"]
+shifts: ["ejknf"]
+state: {
+  "boardState": [
+    "point",
+    "child",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "absent",
+      "correct",
+      "absent",
+      "absent"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null,
+    null,
+    null,
+    null
+  ],
+  "rowIndex": 2,
+  "solution": "child",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1703859660000,
+  "lastCompletedTs": 1703859660000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 1314,
+  "dayOffset": 923,
+  "timestamp": 1703859660
+}
+stats: {
+  "currentStreak": 21,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 11,
+    "3": 34,
+    "4": 62,
+    "5": 26,
+    "6": 16,
+    "fail": 0
+  },
+  "winPercentage": 100,
+  "gamesPlayed": 149,
+  "gamesWon": 149,
+  "averageGuesses": 4,
+  "isOnStreak": true,
+  "hasPlayed": true
+}
+---
+<!-- more -->


### PR DESCRIPTION
## Summary
- add entry for Dec 29, 2023 Wordle solved in two guesses

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_68c50c696bbc832381ea078bef79a06a