### PR TITLE
feat: add jan 10 2024 puzzle

### DIFF
--- a/content/w/2024-01-10/index.md
+++ b/content/w/2024-01-10/index.md
@@ -1,0 +1,84 @@
+---
+title: "935: 2024-01-10"
+date: 2024-01-10T07:07:00-08:00
+tags: []
+git_branch: 2024-01-10_935
+contests: []
+words: ["point","trade","threw"]
+openers: ["point"]
+middlers: ["trade"]
+puzzles: [935]
+hashes: ["AAAAPCPAAPCCCCCXXXXXXXXXXXXXXX"]
+shifts: ["zozng"]
+state: {
+  "boardState": [
+    "point",
+    "trade",
+    "threw",
+    "",
+    "",
+    ""
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "absent",
+      "absent",
+      "absent",
+      "present"
+    ],
+    [
+      "correct",
+      "present",
+      "absent",
+      "absent",
+      "present"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null,
+    null,
+    null
+  ],
+  "rowIndex": 3,
+  "solution": "threw",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1704899220000,
+  "lastCompletedTs": 1704899220000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 1445,
+  "dayOffset": 935,
+  "timestamp": 1704899220
+}
+stats: {
+  "currentStreak": 5,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 10,
+    "3": 37,
+    "4": 66,
+    "5": 29,
+    "6": 16,
+    "fail": 1
+  },
+  "winPercentage": 99,
+  "gamesPlayed": 159,
+  "gamesWon": 158,
+  "averageGuesses": 4,
+  "isOnStreak": true,
+  "hasPlayed": true
+}
+---
+<!-- more -->
+Solved in three guesses.


### PR DESCRIPTION
## Summary
- add Wordle puzzle data for 2024-01-10

## Testing
- `cat content/w/2024-01-10/index.md | npx zx content/r/guess-words.md` *(fails: E403 Forbidden - GET https://registry.npmjs.org/zx)*
- `cat content/w/2024-01-10/index.md | npx zx content/r/guess-count.md` *(fails: E403 Forbidden - GET https://registry.npmjs.org/zx)*
- `cat content/w/2024-01-10/index.md | npx zx content/r/outcome.md` *(fails: E403 Forbidden - GET https://registry.npmjs.org/zx)*

------
https://chatgpt.com/codex/tasks/task_e_68c50cb0dde883239541228215703172