### PR TITLE
Add Feb 5 2024 Wordle puzzle

### DIFF
--- a/content/w/2024-02-05/index.md
+++ b/content/w/2024-02-05/index.md
@@ -1,0 +1,89 @@
+---
+title: "961: 2024-02-05"
+date: 2024-02-05T15:01:00-08:00
+tags: []
+git_branch: 2024-02-05_961
+contests: []
+words: ["erupt","spear","peril","repel"]
+openers: ["erupt"]
+middlers: ["spear","peril"]
+puzzles: [961]
+hashes: ["PPAPAAPPAPPCPACCCCCCXXXXXXXXXX"]
+shifts: ["xlxnv"]
+state: {
+  "boardState": [
+    "erupt",
+    "spear",
+    "peril",
+    "repel",
+    "",
+    ""
+  ],
+  "evaluations": [
+    [
+      "present",
+      "present",
+      "absent",
+      "present",
+      "absent"
+    ],
+    [
+      "absent",
+      "present",
+      "present",
+      "absent",
+      "present"
+    ],
+    [
+      "present",
+      "correct",
+      "present",
+      "absent",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null,
+    null
+  ],
+  "rowIndex": 4,
+  "solution": "repel",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1707174060000,
+  "lastCompletedTs": 1707174060000,
+  "hardMode": false,
+  "settings": {
+    "hardMode": false,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 0,
+  "dayOffset": 961,
+  "timestamp": 1707174060
+}
+stats: {
+  "currentStreak": 1,
+  "maxStreak": 1,
+  "guesses": {
+    "1": 0,
+    "2": 0,
+    "3": 0,
+    "4": 1,
+    "5": 0,
+    "6": 0,
+    "fail": 0
+  },
+  "winPercentage": 100,
+  "gamesPlayed": 1,
+  "gamesWon": 1,
+  "averageGuesses": 4,
+  "isOnStreak": false,
+  "hasPlayed": true
+}
+---
+<!-- more -->

--- a/content/words/repel/_index.md
+++ b/content/words/repel/_index.md
@@ -1,0 +1,3 @@
+---
+title: repel
+---


### PR DESCRIPTION
## Summary
- add Wordle puzzle entry for 2024-02-05 with solution "repel"
- record guesses and stats for "erupt", "spear", "peril" leading to solve in four
- add word page for `repel`

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_68c50d2a6e9483238f3076397d58d3ae