### PR TITLE
Add puzzle for 2024-02-01

### DIFF
--- a/content/w/2024-02-01/index.md
+++ b/content/w/2024-02-01/index.md
@@ -1,0 +1,89 @@
+---
+title: "957: 2024-02-01"
+date: 2024-02-01T06:42:00-08:00
+tags: []
+git_branch: 2024-02-01_957
+contests: []
+words: ["great","beach","panel","alive"]
+openers: ["great"]
+middlers: ["beach","panel"]
+puzzles: [957]
+hashes: ["AAPPAAPPAAAPAPPCCCCCXXXXXXXXXX"]
+shifts: ["gsqeo"]
+state: {
+  "boardState": [
+    "great",
+    "beach",
+    "panel",
+    "alive",
+    "",
+    ""
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "absent",
+      "present",
+      "present",
+      "absent"
+    ],
+    [
+      "absent",
+      "present",
+      "present",
+      "absent",
+      "absent"
+    ],
+    [
+      "absent",
+      "present",
+      "absent",
+      "present",
+      "present"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null,
+    null
+  ],
+  "rowIndex": 4,
+  "solution": "alive",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1706798520000,
+  "lastCompletedTs": 1706798520000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 2033,
+  "dayOffset": 957,
+  "timestamp": 1706798520
+}
+stats: {
+  "currentStreak": 22,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 10,
+    "3": 41,
+    "4": 73,
+    "5": 35,
+    "6": 20,
+    "fail": 1
+  },
+  "winPercentage": 99,
+  "gamesPlayed": 180,
+  "gamesWon": 179,
+  "averageGuesses": 4,
+  "isOnStreak": true,
+  "hasPlayed": true
+}
+---
+<!-- more -->


### PR DESCRIPTION
## Summary
- add Wordle puzzle entry for 2024-02-01 with solution "alive"

## Testing
- `hugo -d /tmp/test-build`

------
https://chatgpt.com/codex/tasks/task_e_68c50cf0df3c83239d758a428bcede4f