### PR TITLE
Standardize emoji grid columns across all puzzle list pages

### DIFF
--- a/content/all-vowels-guessed.md
+++ b/content/all-vowels-guessed.md
@@ -14,7 +14,7 @@ Definition: Puzzles where each vowel (A, E, I, O, U) appears at least once acros
       <th>Puzzle</th>
       <th>Turns</th>
       <th>Score</th>
-      <th>Puzzle</th>
+      <th>Grid</th>
     </tr>
 
     {{ range sort $found "date" "desc" }}

--- a/content/all-vowels-plus-y.md
+++ b/content/all-vowels-plus-y.md
@@ -14,7 +14,7 @@ Definition: Puzzles where each vowel (A, E, I, O, U) and Y appear at least once 
       <th>Puzzle</th>
       <th>Turns</th>
       <th>Score</th>
-      <th>Puzzle</th>
+      <th>Grid</th>
     </tr>
 
     {{ range sort $found "date" "desc" }}

--- a/content/alphabet-pangrams.md
+++ b/content/alphabet-pangrams.md
@@ -14,7 +14,7 @@ Definition: Puzzles where every letter of the alphabet appears at least once acr
       <th>Puzzle</th>
       <th>Turns</th>
       <th>Score</th>
-      <th>Puzzle</th>
+      <th>Grid</th>
     </tr>
 
     {{ range sort $found "date" "desc" }}

--- a/content/anagrams.md
+++ b/content/anagrams.md
@@ -14,7 +14,7 @@ Definition: Puzzles which contain a non-solving guess with all letters correct o
       <th>Puzzle</th>
       <th>Turns</th>
       <th>Score</th>
-      <th>Puzzle</th>
+      <th>Grid</th>
     </tr>
 
     {{ range sort $found "date" "desc" }}

--- a/content/back-half-alphabet-pangrams.md
+++ b/content/back-half-alphabet-pangrams.md
@@ -14,7 +14,7 @@ Definition: Puzzles where every letter from N to Z appears at least once across 
       <th>Puzzle</th>
       <th>Turns</th>
       <th>Score</th>
-      <th>Puzzle</th>
+      <th>Grid</th>
     </tr>
 
     {{ range sort $found "date" "desc" }}

--- a/content/front-half-alphabet-pangrams.md
+++ b/content/front-half-alphabet-pangrams.md
@@ -14,7 +14,7 @@ Definition: Puzzles where every letter from A to M appears at least once across 
       <th>Puzzle</th>
       <th>Turns</th>
       <th>Score</th>
-      <th>Puzzle</th>
+      <th>Grid</th>
     </tr>
 
     {{ range sort $found "date" "desc" }}

--- a/content/homogenous-guesses-only.md
+++ b/content/homogenous-guesses-only.md
@@ -17,7 +17,7 @@ Definition: Puzzles in which each guess contains either only present (yellow) or
       <th>Puzzle</th>
       <th>Turns</th>
       <th>Score</th>
-      <th>Puzzle</th>
+      <th>Grid</th>
     </tr>
 
     {{ range sort $found "date" "desc" }}

--- a/content/losses.md
+++ b/content/losses.md
@@ -20,6 +20,7 @@ title: Losses
       <th>Puzzle</th>
       <th>Turns</th>
       <th>Score</th>
+      <th>Grid</th>
     </tr>
 
     {{ range sort $found "Date" "desc" }}
@@ -28,6 +29,7 @@ title: Losses
         <td><a href="{{ .RelPermalink }}">{{ index .Params.puzzles 0 }}</td>
         <td><a href="{{ .RelPermalink }}">{{ partialCached "guess-count.html" . .File.Path }}{{- cond (eq .Params.state.hardMode true) "*" "" -}}</a></td>
         <td><a href="{{ .RelPermalink }}">{{ partialCached "puzzle-score.html" . .File.Path }}</a></td>
+        <td>{{ partialCached "emoji-grid" . .File.Path }}</td>
       </tr>
 
     {{ end }}

--- a/content/no-green-before-solve.md
+++ b/content/no-green-before-solve.md
@@ -17,7 +17,7 @@ Definition: Puzzles won in which no letters are correct until the final, solving
       <th>Puzzle</th>
       <th>Turns</th>
       <th>Score</th>
-      <th>Puzzle</th>
+      <th>Grid</th>
     </tr>
 
     {{ range sort $found "date" "desc" }}

--- a/content/no-yellow-tiles.md
+++ b/content/no-yellow-tiles.md
@@ -18,7 +18,7 @@ Definition: Puzzles where all letters in all guesses are either absent or correc
       <th>Puzzle</th>
       <th>Turns</th>
       <th>Score</th>
-      <th>Puzzle</th>
+      <th>Grid</th>
     </tr>
 
     {{ range sort $found "date" "desc" }}

--- a/content/opener-double-misses.md
+++ b/content/opener-double-misses.md
@@ -21,7 +21,7 @@ Definition: Puzzles where all letters in my first two guesses were absent.
       <th>Puzzle</th>
       <th>Turns</th>
       <th>Score</th>
-      <th>Puzzle</th>
+      <th>Grid</th>
     </tr>
 
     {{ range sort $found "date" "desc" }}

--- a/content/opener-misses.md
+++ b/content/opener-misses.md
@@ -23,7 +23,7 @@ Definition: Puzzles where all letters in my opening guess were absent, excluding
       <th>Puzzle</th>
       <th>Turns</th>
       <th>Score</th>
-      <th>Puzzle</th>
+      <th>Grid</th>
     </tr>
 
     {{ range sort $found "date" "desc" }}

--- a/content/single-letter-guesses.md
+++ b/content/single-letter-guesses.md
@@ -15,7 +15,7 @@ Definition: Puzzles containing a guess made up of the same letter in all five po
       <th>Turns</th>
       <th>Score</th>
       <th>Guess</th>
-      <th>Puzzle</th>
+      <th>Grid</th>
     </tr>
 
     {{ range sort $found "date" "desc" }}

--- a/content/solve-in-five.md
+++ b/content/solve-in-five.md
@@ -23,6 +23,7 @@ title: Puzzles Solved in Five Guesses
       <th>Puzzle</th>
       <th>Turns</th>
       <th>Score</th>
+      <th>Grid</th>
     </tr>
 
     {{ range sort $found "Date" "desc" }}
@@ -31,6 +32,7 @@ title: Puzzles Solved in Five Guesses
         <td><a href="{{ .RelPermalink }}">{{ index .Params.puzzles 0 }}</td>
         <td><a href="{{ .RelPermalink }}">{{ partialCached "guess-count.html" . .File.Path }}{{- cond (eq .Params.state.hardMode true) "*" "" -}}</a></td>
         <td><a href="{{ .RelPermalink }}">{{ partialCached "puzzle-score.html" . .File.Path }}</a></td>
+        <td>{{ partialCached "emoji-grid" . .File.Path }}</td>
       </tr>
 
     {{ end }}

--- a/content/solve-in-four.md
+++ b/content/solve-in-four.md
@@ -23,6 +23,7 @@ title: Puzzles Solved in Four Guesses
       <th>Puzzle</th>
       <th>Turns</th>
       <th>Score</th>
+      <th>Grid</th>
     </tr>
 
     {{ range sort $found "Date" "desc" }}
@@ -31,6 +32,7 @@ title: Puzzles Solved in Four Guesses
         <td><a href="{{ .RelPermalink }}">{{ index .Params.puzzles 0 }}</td>
         <td><a href="{{ .RelPermalink }}">{{ partialCached "guess-count.html" . .File.Path }}{{- cond (eq .Params.state.hardMode true) "*" "" -}}</a></td>
         <td><a href="{{ .RelPermalink }}">{{ partialCached "puzzle-score.html" . .File.Path }}</a></td>
+        <td>{{ partialCached "emoji-grid" . .File.Path }}</td>
       </tr>
 
     {{ end }}

--- a/content/solve-in-one.md
+++ b/content/solve-in-one.md
@@ -23,6 +23,7 @@ title: Puzzles Solved in One Guess
       <th>Puzzle</th>
       <th>Turns</th>
       <th>Score</th>
+      <th>Grid</th>
     </tr>
 
     {{ range sort $found "Date" "desc" }}
@@ -31,6 +32,7 @@ title: Puzzles Solved in One Guess
         <td><a href="{{ .RelPermalink }}">{{ index .Params.puzzles 0 }}</td>
         <td><a href="{{ .RelPermalink }}">{{ partialCached "guess-count.html" . .File.Path }}{{- cond (eq .Params.state.hardMode true) "*" "" -}}</a></td>
         <td><a href="{{ .RelPermalink }}">{{ partialCached "puzzle-score.html" . .File.Path }}</a></td>
+        <td>{{ partialCached "emoji-grid" . .File.Path }}</td>
       </tr>
 
     {{ end }}

--- a/content/solve-in-six.md
+++ b/content/solve-in-six.md
@@ -23,6 +23,7 @@ title: Puzzles Solved in Six Guesses
       <th>Puzzle</th>
       <th>Turns</th>
       <th>Score</th>
+      <th>Grid</th>
     </tr>
 
     {{ range sort $found "Date" "desc" }}
@@ -31,6 +32,7 @@ title: Puzzles Solved in Six Guesses
         <td><a href="{{ .RelPermalink }}">{{ index .Params.puzzles 0 }}</td>
         <td><a href="{{ .RelPermalink }}">{{ partialCached "guess-count.html" . .File.Path }}{{- cond (eq .Params.state.hardMode true) "*" "" -}}</a></td>
         <td><a href="{{ .RelPermalink }}">{{ partialCached "puzzle-score.html" . .File.Path }}</a></td>
+        <td>{{ partialCached "emoji-grid" . .File.Path }}</td>
       </tr>
 
     {{ end }}

--- a/content/solve-in-three.md
+++ b/content/solve-in-three.md
@@ -23,6 +23,7 @@ title: Puzzles Solved in Three Guesses
       <th>Puzzle</th>
       <th>Turns</th>
       <th>Score</th>
+      <th>Grid</th>
     </tr>
 
     {{ range sort $found "Date" "desc" }}
@@ -31,6 +32,7 @@ title: Puzzles Solved in Three Guesses
         <td><a href="{{ .RelPermalink }}">{{ index .Params.puzzles 0 }}</td>
         <td><a href="{{ .RelPermalink }}">{{ partialCached "guess-count.html" . .File.Path }}{{- cond (eq .Params.state.hardMode true) "*" "" -}}</a></td>
         <td><a href="{{ .RelPermalink }}">{{ partialCached "puzzle-score.html" . .File.Path }}</a></td>
+        <td>{{ partialCached "emoji-grid" . .File.Path }}</td>
       </tr>
 
     {{ end }}

--- a/content/solve-in-two.md
+++ b/content/solve-in-two.md
@@ -24,6 +24,7 @@ title: Puzzles Solved in Two Guesses
       <th>Puzzle</th>
       <th>Turns</th>
       <th>Score</th>
+      <th>Grid</th>
     </tr>
 
     {{ range sort $found "Date" "desc" }}
@@ -32,6 +33,7 @@ title: Puzzles Solved in Two Guesses
         <td><a href="{{ .RelPermalink }}">{{ index .Params.puzzles 0 }}</td>
         <td><a href="{{ .RelPermalink }}">{{ partialCached "guess-count.html" . .File.Path }}{{- cond (eq .Params.state.hardMode true) "*" "" -}}</a></td>
         <td><a href="{{ .RelPermalink }}">{{ partialCached "puzzle-score.html" . .File.Path }}</a></td>
+        <td>{{ partialCached "emoji-grid" . .File.Path }}</td>
       </tr>
 
     {{ end }}

--- a/content/symmetrical.md
+++ b/content/symmetrical.md
@@ -16,7 +16,7 @@ Definition: Puzzles which are symmetrical or mirrored vertically.
       <th>Puzzle</th>
       <th>Turns</th>
       <th>Score</th>
-      <th>Puzzle</th>
+      <th>Grid</th>
     </tr>
 
     {{ range sort $found "date" "desc" }}


### PR DESCRIPTION
- Add missing emoji grid column to solve-in-one.md
- Standardize all emoji grid column headers to "Grid"
- Ensure consistent table layout across all puzzle collection pages
- Update 20 puzzle list pages with standardized grid column headers

🤖 Generated with [Claude Code](https://claude.ai/code)