### PR TITLE
Add monthly usage counts to word scorecard

### DIFF
--- a/layouts/partials/word-scorecard.html
+++ b/layouts/partials/word-scorecard.html
@@ -10,6 +10,11 @@
   {{ $scratch.Set (printf "dow-%s" .) 0 }}
 {{ end }}
 
+{{/* initialize month counts */}}
+{{ range (slice "January" "February" "March" "April" "May" "June" "July" "August" "September" "October" "November" "December") }}
+  {{ $scratch.Set (printf "month-%s" .) 0 }}
+{{ end }}
+
 {{/* initialize diff counts 0 to -10 */}}
 {{ range seq 0 10 }}
   {{ $v := mul . -1 }}
@@ -57,6 +62,9 @@
     {{ $dow := dateFormat "Monday" .Date }}
     {{ $scratch.Set (printf "dow-%s" $dow) (add ($scratch.Get (printf "dow-%s" $dow)) 1) }}
 
+    {{ $month := dateFormat "January" .Date }}
+    {{ $scratch.Set (printf "month-%s" $month) (add ($scratch.Get (printf "month-%s" $month)) 1) }}
+
     {{ $year := dateFormat "2006" .Date }}
     {{ $years := $scratch.Get "years" }}
     {{ $yearCount := cond (isset $years $year) (index $years $year) 0 }}
@@ -97,6 +105,16 @@
       <tr>
         <th>{{ . }}</th>
         <td>{{ $scratch.Get (printf "dow-%s" .) }}</td>
+      </tr>
+    {{ end }}
+  </table>
+
+  <h3>Month</h3>
+  <table>
+    {{ range (slice "January" "February" "March" "April" "May" "June" "July" "August" "September" "October" "November" "December") }}
+      <tr>
+        <th>{{ . }}</th>
+        <td>{{ $scratch.Get (printf "month-%s" .) }}</td>
       </tr>
     {{ end }}
   </table>


### PR DESCRIPTION
## Summary
- add per-month counters to the word scorecard template
- display month totals alongside existing guess, day, and year stats

## Testing
- `hugo` *(fails: build process did not complete within time limit)*
- `node static/tools/enhance/enrich-emoji.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c6ecd32e488323b0ea6ba3fc5de401