### PR TITLE
Add hour of day puzzle breakdown

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -583,6 +583,38 @@
   {{ end }}
 </table>
 
+{{ $hours := partial "hourly-breakdown.html" $wordles }}
+<h2>⌚ Hour of Day Breakdown</h2>
+<table>
+  <tr>
+    <th>Hour</th>
+    <th>Puzzles</th>
+    <th>Avg Guesses</th>
+    <th>Avg Score</th>
+    <th>Wins</th>
+    <th>Losses</th>
+  </tr>
+  {{ range seq 0 23 }}
+    {{ $h := printf "%02d" . }}
+    {{ $s := index $hours $h }}
+    {{ $count := index $s "count" }}
+    {{ $avgGuesses := 0.0 }}
+    {{ $avgScore := 0.0 }}
+    {{ if gt $count 0 }}
+      {{ $avgGuesses = div (float (index $s "guesses")) $count }}
+      {{ $avgScore = div (float (index $s "score")) $count }}
+    {{ end }}
+    <tr>
+      <td>{{ $h }}</td>
+      <td>{{ $count }}</td>
+      <td>{{ $avgGuesses | lang.FormatNumber 2 }}</td>
+      <td>{{ $avgScore | lang.FormatNumber 2 }}</td>
+      <td>{{ index $s "wins" }}</td>
+      <td>{{ index $s "losses" }}</td>
+    </tr>
+  {{ end }}
+</table>
+
 <h2>📒 Articles</h2>
 <ul>
   {{ range (where .Site.RegularPages.ByDate.Reverse "Section" "a") }}

--- a/layouts/partials/hourly-breakdown.html
+++ b/layouts/partials/hourly-breakdown.html
@@ -1,0 +1,18 @@
+{{- $wordles := . -}}
+{{- $hours := dict -}}
+{{- range seq 0 23 -}}
+  {{- $hours = merge $hours (dict (printf "%02d" .) (dict "count" 0 "wins" 0 "losses" 0 "guesses" 0 "score" 0)) -}}
+{{- end -}}
+{{- range $w := $wordles -}}
+  {{- $hour := dateFormat "15" $w.Date -}}
+  {{- $stats := index $hours $hour -}}
+  {{- $count := add (index $stats "count") 1 -}}
+  {{- $guesses := partialCached "guess-count.html" $w $w.File.Path -}}
+  {{- $guesses = cond (eq $guesses "X") 6 $guesses -}}
+  {{- $guesses = add (index $stats "guesses") $guesses -}}
+  {{- $score := add (index $stats "score") (partialCached "puzzle-score.html" $w $w.File.Path) -}}
+  {{- $wins := add (index $stats "wins") (cond (eq $w.Params.state.gameStatus "WIN") 1 0) -}}
+  {{- $losses := add (index $stats "losses") (cond (eq $w.Params.state.gameStatus "FAIL") 1 0) -}}
+  {{- $hours = merge $hours (dict $hour (dict "count" $count "wins" $wins "losses" $losses "guesses" $guesses "score" $score)) -}}
+{{- end -}}
+{{- return $hours -}}


### PR DESCRIPTION
## Summary
- move hourly breakdown table rendering into index page
- make hourly breakdown partial return stats data only
- show hour-of-day table just below top letter variety section

## Testing
- `hugo --minify`


------
https://chatgpt.com/codex/tasks/task_e_68c7b1fe1dd88323b5b7053cf06c404e