### PR TITLE
Add Wordle-inspired footer fleuron

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -32,54 +32,59 @@
       </p>
     {{ end }}
     <div style="opacity:0.5; text-align:center">
-      🛠 by <a href="https://tomhummel.com">Tom Hummel</a>
-    </div>
-    <div style="text-align:center; margin: 1rem 0;">
-      <svg
-        aria-hidden="true"
-        focusable="false"
-        role="presentation"
-        width="180"
-        height="60"
-        viewBox="0 0 178 54"
-        xmlns="http://www.w3.org/2000/svg"
+      🛠 by
+      <a
+        href="https://tomhummel.com"
+        aria-label="Tom Hummel"
+        style="display:inline-flex; align-items:center; gap:0.35em;"
       >
-        <g>
-          <rect x="0" y="0" width="54" height="54" rx="6" fill="#538d4e" stroke="#121213" stroke-width="2" />
-          <text
-            x="27"
-            y="27"
-            font-family="'Clear Sans', 'Helvetica Neue', Arial, sans-serif"
-            font-weight="700"
-            font-size="28"
-            fill="#f8f8f8"
-            text-anchor="middle"
-            dominant-baseline="middle"
-          >T</text>
-          <rect x="62" y="0" width="54" height="54" rx="6" fill="#b59f3b" stroke="#121213" stroke-width="2" />
-          <text
-            x="89"
-            y="27"
-            font-family="'Clear Sans', 'Helvetica Neue', Arial, sans-serif"
-            font-weight="700"
-            font-size="28"
-            fill="#f8f8f8"
-            text-anchor="middle"
-            dominant-baseline="middle"
-          >P</text>
-          <rect x="124" y="0" width="54" height="54" rx="6" fill="#3a3a3c" stroke="#121213" stroke-width="2" />
-          <text
-            x="151"
-            y="27"
-            font-family="'Clear Sans', 'Helvetica Neue', Arial, sans-serif"
-            font-weight="700"
-            font-size="28"
-            fill="#f8f8f8"
-            text-anchor="middle"
-            dominant-baseline="middle"
-          >H</text>
-        </g>
-      </svg>
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          role="presentation"
+          width="3.3em"
+          height="1em"
+          viewBox="0 0 178 54"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g>
+            <rect x="0" y="0" width="54" height="54" rx="6" fill="#538d4e" stroke="#121213" stroke-width="2" />
+            <text
+              x="27"
+              y="27"
+              font-family="'Clear Sans', 'Helvetica Neue', Arial, sans-serif"
+              font-weight="700"
+              font-size="28"
+              fill="#f8f8f8"
+              text-anchor="middle"
+              dominant-baseline="middle"
+            >T</text>
+            <rect x="62" y="0" width="54" height="54" rx="6" fill="#b59f3b" stroke="#121213" stroke-width="2" />
+            <text
+              x="89"
+              y="27"
+              font-family="'Clear Sans', 'Helvetica Neue', Arial, sans-serif"
+              font-weight="700"
+              font-size="28"
+              fill="#f8f8f8"
+              text-anchor="middle"
+              dominant-baseline="middle"
+            >P</text>
+            <rect x="124" y="0" width="54" height="54" rx="6" fill="#3a3a3c" stroke="#121213" stroke-width="2" />
+            <text
+              x="151"
+              y="27"
+              font-family="'Clear Sans', 'Helvetica Neue', Arial, sans-serif"
+              font-weight="700"
+              font-size="28"
+              fill="#f8f8f8"
+              text-anchor="middle"
+              dominant-baseline="middle"
+            >H</text>
+          </g>
+        </svg>
+        Hummel
+      </a>
     </div>
     <div style="opacity:0.5; text-align:center">
       💛 No cookies. No third-party javascript. 💚

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -83,7 +83,84 @@
             >M</text>
           </g>
         </svg>
-        Hummel
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          role="presentation"
+          width="6.7em"
+          height="1em"
+          viewBox="0 0 364 54"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g>
+            <rect x="0" y="0" width="54" height="54" rx="6" fill="#538d4e" stroke="#121213" stroke-width="2" />
+            <text
+              x="27"
+              y="27"
+              font-family="'Clear Sans', 'Helvetica Neue', Arial, sans-serif"
+              font-weight="700"
+              font-size="28"
+              fill="#f8f8f8"
+              text-anchor="middle"
+              dominant-baseline="middle"
+            >H</text>
+            <rect x="62" y="0" width="54" height="54" rx="6" fill="#b59f3b" stroke="#121213" stroke-width="2" />
+            <text
+              x="89"
+              y="27"
+              font-family="'Clear Sans', 'Helvetica Neue', Arial, sans-serif"
+              font-weight="700"
+              font-size="28"
+              fill="#f8f8f8"
+              text-anchor="middle"
+              dominant-baseline="middle"
+            >U</text>
+            <rect x="124" y="0" width="54" height="54" rx="6" fill="#3a3a3c" stroke="#121213" stroke-width="2" />
+            <text
+              x="151"
+              y="27"
+              font-family="'Clear Sans', 'Helvetica Neue', Arial, sans-serif"
+              font-weight="700"
+              font-size="28"
+              fill="#f8f8f8"
+              text-anchor="middle"
+              dominant-baseline="middle"
+            >M</text>
+            <rect x="186" y="0" width="54" height="54" rx="6" fill="#538d4e" stroke="#121213" stroke-width="2" />
+            <text
+              x="213"
+              y="27"
+              font-family="'Clear Sans', 'Helvetica Neue', Arial, sans-serif"
+              font-weight="700"
+              font-size="28"
+              fill="#f8f8f8"
+              text-anchor="middle"
+              dominant-baseline="middle"
+            >M</text>
+            <rect x="248" y="0" width="54" height="54" rx="6" fill="#b59f3b" stroke="#121213" stroke-width="2" />
+            <text
+              x="275"
+              y="27"
+              font-family="'Clear Sans', 'Helvetica Neue', Arial, sans-serif"
+              font-weight="700"
+              font-size="28"
+              fill="#f8f8f8"
+              text-anchor="middle"
+              dominant-baseline="middle"
+            >E</text>
+            <rect x="310" y="0" width="54" height="54" rx="6" fill="#3a3a3c" stroke="#121213" stroke-width="2" />
+            <text
+              x="337"
+              y="27"
+              font-family="'Clear Sans', 'Helvetica Neue', Arial, sans-serif"
+              font-weight="700"
+              font-size="28"
+              fill="#f8f8f8"
+              text-anchor="middle"
+              dominant-baseline="middle"
+            >L</text>
+          </g>
+        </svg>
       </a>
     </div>
     <div style="opacity:0.5; text-align:center">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -69,7 +69,7 @@
               fill="#f8f8f8"
               text-anchor="middle"
               dominant-baseline="middle"
-            >P</text>
+            >O</text>
             <rect x="124" y="0" width="54" height="54" rx="6" fill="#3a3a3c" stroke="#121213" stroke-width="2" />
             <text
               x="151"
@@ -80,7 +80,7 @@
               fill="#f8f8f8"
               text-anchor="middle"
               dominant-baseline="middle"
-            >H</text>
+            >M</text>
           </g>
         </svg>
         Hummel

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -34,6 +34,53 @@
     <div style="opacity:0.5; text-align:center">
       🛠 by <a href="https://tomhummel.com">Tom Hummel</a>
     </div>
+    <div style="text-align:center; margin: 1rem 0;">
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        role="presentation"
+        width="180"
+        height="60"
+        viewBox="0 0 178 54"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g>
+          <rect x="0" y="0" width="54" height="54" rx="6" fill="#538d4e" stroke="#121213" stroke-width="2" />
+          <text
+            x="27"
+            y="27"
+            font-family="'Clear Sans', 'Helvetica Neue', Arial, sans-serif"
+            font-weight="700"
+            font-size="28"
+            fill="#f8f8f8"
+            text-anchor="middle"
+            dominant-baseline="middle"
+          >T</text>
+          <rect x="62" y="0" width="54" height="54" rx="6" fill="#b59f3b" stroke="#121213" stroke-width="2" />
+          <text
+            x="89"
+            y="27"
+            font-family="'Clear Sans', 'Helvetica Neue', Arial, sans-serif"
+            font-weight="700"
+            font-size="28"
+            fill="#f8f8f8"
+            text-anchor="middle"
+            dominant-baseline="middle"
+          >P</text>
+          <rect x="124" y="0" width="54" height="54" rx="6" fill="#3a3a3c" stroke="#121213" stroke-width="2" />
+          <text
+            x="151"
+            y="27"
+            font-family="'Clear Sans', 'Helvetica Neue', Arial, sans-serif"
+            font-weight="700"
+            font-size="28"
+            fill="#f8f8f8"
+            text-anchor="middle"
+            dominant-baseline="middle"
+          >H</text>
+        </g>
+      </svg>
+    </div>
     <div style="opacity:0.5; text-align:center">
       💛 No cookies. No third-party javascript. 💚
     </div>


### PR DESCRIPTION
## Summary
- add an inline Wordle-style SVG motif to the global footer so every page shows a TPH tile fleuron

## Testing
- hugo --minify

------
https://chatgpt.com/codex/tasks/task_e_68ca29c5d23883239789117bb4336259