### PR TITLE
Show emoji grid on hash listing

### DIFF
--- a/layouts/taxonomy/hash.terms.html
+++ b/layouts/taxonomy/hash.terms.html
@@ -10,7 +10,7 @@
 <h2>List</h2>
 <table>
   <tr>
-    <td>Puzzle Hash</td>
+    <td>Emoji Grid</td>
     <td>Count</td>
     <td>First Played</td>
     <td>Last Played</td>
@@ -27,7 +27,7 @@
 
     {{ with $.Site.GetPage (printf "/%s/%s" "hashes" $name) }}
     <tr>
-      <td><a href="{{ .RelPermalink }}">{{ .Name }}</a></td>
+      <td><a href="{{ .RelPermalink }}" title="{{ .Name }}">{{ partialCached "emoji-grid" $first $first.File.Path }}</a></td>
       <td>{{ $count }}</td>
       <td><a href="{{ $first.RelPermalink}}">{{ $first.Date.Format "Jan 2, 2006" }}</a></td>
       <td>{{ if gt $count 1 }}<a href="{{ $last.RelPermalink}}">{{ $last.Date.Format "Jan 2, 2006" }}</a>{{ else }}--{{ end }}</td>


### PR DESCRIPTION
## Summary
- replace the hash text column on the hash taxonomy list with the emoji grid for a representative puzzle
- add a tooltip containing the hash string while keeping the rest of the table unchanged

## Testing
- hugo --minify

------
https://chatgpt.com/codex/tasks/task_e_68d1554c85c0832399dc9cfb76c23d7e