### PR TITLE
Use shiny icons for vowel achievements

### DIFF
--- a/layouts/w/single.html
+++ b/layouts/w/single.html
@@ -85,11 +85,11 @@
     {{ $achievements = $achievements | append (slice $achievement) }}
   {{ end }}
   {{ with (partialCached "all-vowels" $wordle .File.Path) }}
-    {{ $achievement := dict "badge" "🅰️" "report" "all-vowels-guessed.md" "title" "All Vowels Guessed" }}
+    {{ $achievement := dict "badge" "🏆" "report" "all-vowels-guessed.md" "title" "All Vowels Guessed" }}
     {{ $achievements = $achievements | append (slice $achievement) }}
   {{ end }}
   {{ with (partialCached "all-vowels-plus-y" $wordle .File.Path) }}
-    {{ $achievement := dict "badge" "🅾️" "report" "all-vowels-plus-y.md" "title" "All Vowels Plus Y Guessed" }}
+    {{ $achievement := dict "badge" "🥉" "report" "all-vowels-plus-y.md" "title" "All Vowels Plus Y Guessed" }}
     {{ $achievements = $achievements | append (slice $achievement) }}
   {{ end }}
   {{ range (partialCached "single-letter-guesses.html" $wordle .File.Path) }}


### PR DESCRIPTION
## Summary
- update the single puzzle template so the All Vowels and All Vowels Plus Y achievements use trophy or medal emojis
- ensure these achievements render with the same shiny styling as the rest of the badges

## Testing
- hugo --minify

------
https://chatgpt.com/codex/tasks/task_e_68cd03862b30832399d48a68bc935eb2