### PR TITLE
Sort shifts taxonomy by usage count only

### DIFF
--- a/layouts/taxonomy/shift.terms.html
+++ b/layouts/taxonomy/shift.terms.html
@@ -16,7 +16,7 @@
     <td>Last Played</td>
   </tr>
 
-  {{ range .Data.Terms.ByCount.Reverse }}
+  {{ range .Data.Terms.ByCount }}
     {{ $name := .Name }}
     {{ $count := .Count }}
     {{ $first := index (first 1 .Pages.ByDate) 0 }}


### PR DESCRIPTION
## Summary
- keep the shift listing loop on `.Data.Terms.ByCount` while gathering first and last puzzle links
- drop the secondary sort so shifts are ordered solely by their usage count

## Testing
- hugo --config config.toml

------
https://chatgpt.com/codex/tasks/task_e_68d21f6341e083239536096cf521c947