### PR TITLE
Add true anagram achievement

### DIFF
--- a/content/true-anagrams.md
+++ b/content/true-anagrams.md
@@ -1,0 +1,32 @@
+---
+title: True Anagrams
+---
+
+Definition: Puzzles which include a non-solving guess where every tile is yellow — all five letters are present and none are in the correct position.
+
+{{< om.inline >}}
+  {{ $wordles := where .Site.RegularPages "Section" "w" }}
+  {{ $found := partial "true-anagrams.html" $wordles }}
+
+  <p>Pct of Total: <strong>{{ (mul (div (float (len $found)) (len $wordles)) 100)  | lang.FormatNumber 2 }}% ({{ len $found }} / {{ len $wordles }})</strong></p>
+  <table>
+    <tr>
+      <th>Date</th>
+      <th>Puzzle</th>
+      <th>Turns</th>
+      <th>Score</th>
+      <th>Grid</th>
+    </tr>
+
+    {{ range sort $found "date" "desc" }}
+      <tr>
+        <td><a href="{{ .puzzle.RelPermalink }}">{{ dateFormat "Jan 2, 2006" .date }}</a></td>
+        <td><a href="{{ .puzzle.RelPermalink }}">{{ index .puzzle.Params.puzzles 0 }}</td>
+        <td><a href="{{ .puzzle.RelPermalink }}">{{ partialCached "guess-count.html" .puzzle .puzzle.File.Path }}{{- cond (eq .puzzle.Params.state.hardMode true) "*" "" -}}</a></td>
+        <td><a href="{{ .puzzle.RelPermalink }}">{{ partialCached "puzzle-score.html" .puzzle .puzzle.File.Path }}</a></td>
+        <td>{{ partialCached "emoji-grid" .puzzle .puzzle.File.Path }}</td>
+      </tr>
+
+    {{ end }}
+  </table>
+{{< /om.inline >}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -194,6 +194,15 @@
     </td>
   </tr>
 {{ end }}
+{{ with .Site.GetPage "true-anagrams.md" }}
+  {{ $trueAnagrams := partial "true-anagrams.html" (where .Site.RegularPages "Section" "w") }}
+  <tr>
+    <td><a href="{{ .RelPermalink }}">True Anagrams</a></td>
+    <td>
+      {{ (mul (div (float (len $trueAnagrams)) (len $wordles)) 100)  | lang.FormatNumber 2 }}% (<a href="{{ .RelPermalink }}">{{ len $trueAnagrams }}</a> / {{ len $wordles }})
+    </td>
+  </tr>
+{{ end }}
 {{ with .Site.GetPage "symmetrical.md" }}
   {{ $symmetrical := partial "symmetrical.html" (where .Site.RegularPages "Section" "w") }}
   <tr>

--- a/layouts/partials/emoji-grid.html
+++ b/layouts/partials/emoji-grid.html
@@ -1,13 +1,17 @@
-{{ range $g, $guess := .Params.state.boardState }}
-  {{ range $c, $char := split $guess "" -}}
-    {{ $eval := index $.Params.state.evaluations $g $c }}
-    {{- if eq $eval "correct" -}}
-      🟩
-    {{- else if eq $eval "present" -}}
-      🟨
-    {{- else -}}
-      ⬛️
+{{- $printed := false -}}
+{{- range $g, $guess := .Params.state.boardState -}}
+  {{- if ne $guess "" -}}
+    {{- if $printed -}}<br />{{- end -}}
+    {{- range $c, $char := split $guess "" -}}
+      {{ $eval := index $.Params.state.evaluations $g $c }}
+      {{- if eq $eval "correct" -}}
+        🟩
+      {{- else if eq $eval "present" -}}
+        🟨
+      {{- else -}}
+        ⬛️
+      {{- end -}}
     {{- end -}}
-  {{ end }}
-  {{ if not (eq $guess "") }}<br />{{ end }}
-{{ end }}
+    {{- $printed = true -}}
+  {{- end -}}
+{{- end -}}

--- a/layouts/partials/true-anagrams.html
+++ b/layouts/partials/true-anagrams.html
@@ -1,0 +1,38 @@
+{{ $found := slice }}
+{{ range . }}
+  {{ $wordleDate := .Date }}
+  {{ $wordle := . }}
+
+  {{ $hasTrueAnagramGuess := false }}
+  {{ $isWin := eq "WIN" .Params.state.gameStatus }}
+
+  {{ $numGuesses := partialCached "guess-count.html" $wordle $wordle.File.Path }}
+  {{ $numGuesses = cond (eq "X" $numGuesses) 6 $numGuesses }}
+
+  {{ range $n, $guess := .Params.state.evaluations }}
+    {{ $isFinalGuess := eq (add 1 $n) $numGuesses }}
+    {{ $isSolvingGuess := and $isWin $isFinalGuess }}
+
+    {{ if not $isSolvingGuess }}
+      {{ $presents := 0 }}
+      {{ $corrects := 0 }}
+
+      {{ range $e := $guess }}
+        {{ if eq "present" $e }}
+          {{ $presents = add $presents 1 }}
+        {{ else if eq "correct" $e }}
+          {{ $corrects = add $corrects 1 }}
+        {{ end }}
+      {{ end }}
+
+      {{ if and (eq $presents 5) (eq $corrects 0) }}
+        {{ $hasTrueAnagramGuess = true }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+
+  {{ if $hasTrueAnagramGuess }}
+    {{ $found = $found | append (slice (dict "date" $wordleDate "puzzle" $wordle)) }}
+  {{ end }}
+{{ end }}
+{{ return $found }}

--- a/layouts/w/single.html
+++ b/layouts/w/single.html
@@ -64,6 +64,10 @@
   {{ $achievement := dict "badge" "🏅" "report" "anagrams.md" "title" "Anagram" }}
   {{ $achievements = $achievements | append (slice $achievement) }}
 {{ end }}
+{{ with (partialCached "true-anagrams" $wordle .File.Path) }}
+  {{ $achievement := dict "badge" "🏵️" "report" "true-anagrams.md" "title" "True Anagram" }}
+  {{ $achievements = $achievements | append (slice $achievement) }}
+{{ end }}
 {{ with (partialCached "symmetrical" $wordle .File.Path) }}
   {{ $achievement := dict "badge" "🎖" "report" "symmetrical.md" "title" "Symmetrical" }}
   {{ $achievements = $achievements | append (slice $achievement) }}


### PR DESCRIPTION
## Summary
- add a partial and report page that identify "true anagram" guesses where every tile is yellow
- surface the new true anagram achievement on puzzle pages and in the home page achievement table

## Testing
- hugo

------
https://chatgpt.com/codex/tasks/task_e_68d22c77be8883238e31be8cfc9f90f4