### PR TITLE
Improve opener hash taxonomy presentation

### DIFF
--- a/layouts/partials/openerhash-emoji.html
+++ b/layouts/partials/openerhash-emoji.html
@@ -1,0 +1,24 @@
+{{/*
+  Convert an opener hash string (e.g. "AAPAA") into its emoji representation.
+  The taxonomy stores hashes using the letters:
+    - C: correct (green)
+    - P: present (yellow)
+    - A: absent (black)
+  Some older data may include placeholder "X" characters; treat those as blanks.
+*/}}
+{{- $hash := printf "%s" . -}}
+{{- $tiles := slice -}}
+{{- range (split $hash "") -}}
+  {{- $emoji := "" -}}
+  {{- if eq . "C" -}}
+    {{- $emoji = "🟩" -}}
+  {{- else if eq . "P" -}}
+    {{- $emoji = "🟨" -}}
+  {{- else if or (eq . "A") (eq . "X") -}}
+    {{- $emoji = "⬛️" -}}
+  {{- else -}}
+    {{- $emoji = . -}}
+  {{- end -}}
+  {{- $tiles = $tiles | append $emoji -}}
+{{- end -}}
+{{- return (delimit $tiles "") -}}

--- a/layouts/taxonomy/openerhash.terms.html
+++ b/layouts/taxonomy/openerhash.terms.html
@@ -7,6 +7,14 @@
 <div>{{ . }}</div>
 {{ end }}
 
+{{ $alphabetical := .Data.Terms.Alphabetical }}
+{{ $ordered := sort $alphabetical "Count" "desc" }}
+{{ $distinctCount := len $ordered }}
+{{ $totalPossible := 243 }}
+{{ $percentage := mul (div (float $distinctCount) (float $totalPossible)) 100 }}
+
+<p>I've seen <strong>{{ $distinctCount }}</strong> of {{ $totalPossible }} possible opener hashes ({{ $percentage | lang.FormatNumber 1 }}%).</p>
+
 <h2>List</h2>
 <table>
   <tr>
@@ -17,9 +25,6 @@
     <td>Last Played</td>
   </tr>
 
-  {{ $alphabetical := .Data.Terms.Alphabetical }}
-  {{ $ordered := sort $alphabetical "Count" "desc" }}
-
   {{ range $term := $ordered }}
     {{ $name := $term.Name }}
     {{ $count := $term.Count }}
@@ -29,7 +34,7 @@
     {{ with $.Site.GetPage (printf "/%s/%s" "openerhash" $name) }}
     <tr>
       <td><a href="{{ .RelPermalink }}" title="{{ $name }}">{{ partialCached "first-guess-emoji.html" $first $first.File.Path }}</a></td>
-      <td><a href="{{ .RelPermalink }}">{{ $name }}</a></td>
+      <td><a href="{{ .RelPermalink }}" title="{{ $name }}">{{ partialCached "openerhash-emoji.html" $name $name }}</a></td>
       <td>{{ $count }}</td>
       <td><a href="{{ $first.RelPermalink}}">{{ $first.Date.Format "Jan 2, 2006" }}</a></td>
       <td>{{ if gt $count 1 }}<a href="{{ $last.RelPermalink}}">{{ $last.Date.Format "Jan 2, 2006" }}</a>{{ else }}--{{ end }}</td>


### PR DESCRIPTION
## Summary
- add an at-a-glance count of observed opener hashes and coverage percentage to the taxonomy terms page
- render opener hash terms as emoji via a dedicated partial while keeping the table sorted by usage count

## Testing
- hugo

------
https://chatgpt.com/codex/tasks/task_e_68d3479cf9188323b5fa15076157e210