### PR TITLE
Add percentile rank to puzzle score displays

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -60,6 +60,7 @@
     <th>Puzzle</th>
     <th>Turns</th>
     <th>Score</th>
+    <th>Percentile</th>
   </tr>
 
   {{ range first 5 $wordles }}
@@ -68,6 +69,7 @@
       <td><a href="{{ .RelPermalink }}">{{ index .Params.puzzles 0 }}</a></td>
       <td><a href="{{ .RelPermalink }}">{{ partialCached "guess-count.html" . .File.Path }}{{- cond (eq .Params.state.hardMode true) "*" "" -}}</a></td>
       <td><a href="{{ .RelPermalink }}">{{ partialCached "puzzle-score.html" . .File.Path }}</a></td>
+      <td><a href="{{ .RelPermalink }}">{{ (partialCached "puzzle-score-percentile.html" . .File.Path) | lang.FormatNumber 1 }}%</a></td>
     </tr>
 
   {{ end }}

--- a/layouts/partials/puzzle-score-percentile.html
+++ b/layouts/partials/puzzle-score-percentile.html
@@ -1,0 +1,18 @@
+{{ $score := partialCached "puzzle-score.html" . .File.Path }}
+{{ $wordles := where .Site.RegularPages "Section" "w" }}
+{{ $total := len $wordles }}
+{{ $less := 0 }}
+{{ $equal := 0 }}
+{{ range $puzzle := $wordles }}
+  {{ $otherScore := partialCached "puzzle-score.html" $puzzle $puzzle.File.Path }}
+  {{ if lt $otherScore $score }}
+    {{ $less = add $less 1 }}
+  {{ else if eq $otherScore $score }}
+    {{ $equal = add $equal 1 }}
+  {{ end }}
+{{ end }}
+{{ $percentile := 0.0 }}
+{{ if gt $total 0 }}
+  {{ $percentile = mul (div (float (add $less $equal)) $total) 100 }}
+{{ end }}
+{{ return $percentile }}

--- a/layouts/w/single.html
+++ b/layouts/w/single.html
@@ -268,7 +268,10 @@
 <p>
   <details>
     <summary>
-      Puzzle Score: <strong>{{ partialCached "puzzle-score.html" . .File.Path }}</strong>
+      {{ $puzzleScore := partialCached "puzzle-score.html" . .File.Path }}
+      {{ $puzzlePercentile := partialCached "puzzle-score-percentile.html" . .File.Path }}
+      Puzzle Score: <strong>{{ $puzzleScore }}</strong>
+      (Percentile: {{ $puzzlePercentile | lang.FormatNumber 1 }}%)
     </summary>
     {{ partialCached "puzzle-score-detail.html" . .File.Path }}
   </details>


### PR DESCRIPTION
## Summary
- add a partial to calculate puzzle score percentiles across all recorded puzzles
- surface the percentile next to the puzzle score on single puzzle pages and in the recent puzzles list

## Testing
- hugo --minify

------
https://chatgpt.com/codex/tasks/task_e_68d75f605a8c8323b39cba2a8fd0d532