### PR TITLE
Add August 1-10 2024 Wordle puzzle entries

### DIFF
--- a/content/w/2024-08-01/index.md
+++ b/content/w/2024-08-01/index.md
@@ -1,0 +1,87 @@
+---
+title: "1139: 2024-08-01"
+date: 2024-08-01T12:02:00+01:00
+tags: []
+git_branch: 2024-06-20_1097
+contests: []
+words: ["great","panic","chalk"]
+openers: ["great"]
+middlers: ["panic"]
+puzzles: [1139]
+hashes: ["AAAPAAPAAPCCCCCXXXXXXXXXXXXXXX"]
+openerHashes: ["AAAPA"]
+shifts: ["ioiuu"]
+state: {
+  "boardState": [
+    "great",
+    "panic",
+    "chalk",
+    "",
+    "",
+    ""
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "absent",
+      "absent",
+      "present",
+      "absent"
+    ],
+    [
+      "absent",
+      "present",
+      "absent",
+      "absent",
+      "present"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null,
+    null,
+    null
+  ],
+  "rowIndex": 3,
+  "solution": "chalk",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1722510120000,
+  "lastCompletedTs": 1722510120000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 1139,
+  "dayOffset": 1139,
+  "timestamp": 1722510120
+}
+stats: {
+  "currentStreak": 8,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 13,
+    "3": 74,
+    "4": 129,
+    "5": 56,
+    "6": 36,
+    "fail": 5
+  },
+  "winPercentage": 98,
+  "gamesPlayed": 313,
+  "gamesWon": 308,
+  "averageGuesses": 4,
+  "isOnStreak": true,
+  "hasPlayed": true,
+  "lastWonDayOffset": 1139
+}
+---
+<!-- more -->
+
+**Device Context**: Screenshot taken 2024-08-01 12:02:21 (12:02 PM). Display shows 12:02, 3 WiFi signal bars, battery charging (green indicator). Single tab open on nytimes.com. Image: 1290x2796 pixels, 3.6MP iPhone screenshot.

--- a/content/w/2024-08-02/index.md
+++ b/content/w/2024-08-02/index.md
@@ -1,0 +1,105 @@
+---
+title: "1140: 2024-08-02"
+date: 2024-08-02T12:24:00+02:00
+tags: []
+git_branch: 2024-08-02_1140
+contests: []
+words: ["clean","plate","blame","slave","flare","flake"]
+openers: ["clean"]
+middlers: ["plate","blame","slave","flare"]
+puzzles: [1140]
+hashes: ["ACPPAACCACACCACACCACCCCACCCCCC"]
+openerHashes: ["ACPPA"]
+shifts: ["lsito"]
+state: {
+  "boardState": [
+    "clean",
+    "plate",
+    "blame",
+    "slave",
+    "flare",
+    "flake"
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "correct",
+      "present",
+      "present",
+      "absent"
+    ],
+    [
+      "absent",
+      "correct",
+      "correct",
+      "absent",
+      "correct"
+    ],
+    [
+      "absent",
+      "correct",
+      "correct",
+      "absent",
+      "correct"
+    ],
+    [
+      "absent",
+      "correct",
+      "correct",
+      "absent",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "absent",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ]
+  ],
+  "rowIndex": 6,
+  "solution": "flake",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1722594240000,
+  "lastCompletedTs": 1722594240000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 1140,
+  "dayOffset": 1140,
+  "timestamp": 1722594240
+}
+stats: {
+  "currentStreak": 9,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 13,
+    "3": 74,
+    "4": 129,
+    "5": 56,
+    "6": 37,
+    "fail": 5
+  },
+  "winPercentage": 98,
+  "gamesPlayed": 314,
+  "gamesWon": 309,
+  "averageGuesses": 4,
+  "isOnStreak": true,
+  "hasPlayed": true,
+  "lastWonDayOffset": 1140
+}
+---
+<!-- more -->
+
+**Device Context**: Screenshot taken 2024-08-02 12:24 (12:24 PM) local time. Status bar shows 12:24 alongside the cellular signal indicator and battery icon. Single Safari tab open on nytimes.com with purple address bar theme. Image: 1290x2796 pixels, 3.6MP iPhone screenshot.

--- a/content/w/2024-08-03/index.md
+++ b/content/w/2024-08-03/index.md
@@ -1,0 +1,87 @@
+---
+title: "1141: 2024-08-03"
+date: 2024-08-03T12:11:00+02:00
+tags: []
+git_branch: 2024-08-03_1141
+contests: []
+words: ["child","scull","scale"]
+openers: ["child"]
+middlers: ["scull"]
+puzzles: [1141]
+hashes: ["PAACACCACACCCCCXXXXXXXXXXXXXXX"]
+openerHashes: ["PAACA"]
+shifts: ["yjiuo"]
+state: {
+  "boardState": [
+    "child",
+    "scull",
+    "scale",
+    "",
+    "",
+    ""
+  ],
+  "evaluations": [
+    [
+      "present",
+      "absent",
+      "absent",
+      "correct",
+      "absent"
+    ],
+    [
+      "correct",
+      "correct",
+      "absent",
+      "correct",
+      "absent"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null,
+    null,
+    null
+  ],
+  "rowIndex": 3,
+  "solution": "scale",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1722679860000,
+  "lastCompletedTs": 1722679860000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 1141,
+  "dayOffset": 1141,
+  "timestamp": 1722679860
+}
+stats: {
+  "currentStreak": 10,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 13,
+    "3": 75,
+    "4": 129,
+    "5": 56,
+    "6": 37,
+    "fail": 5
+  },
+  "winPercentage": 98,
+  "gamesPlayed": 315,
+  "gamesWon": 310,
+  "averageGuesses": 4,
+  "isOnStreak": true,
+  "hasPlayed": true,
+  "lastWonDayOffset": 1141
+}
+---
+<!-- more -->
+
+**Device Context**: Screenshot taken 2024-08-03 12:11 (12:11 PM) local time. Status bar reads 12:11 with full cellular signal and battery icons visible. Safari displays nytimes.com with the purple Wordle theme, single tab active. Image: 1290x2796 pixels, 3.6MP iPhone screenshot.

--- a/content/w/2024-08-04/index.md
+++ b/content/w/2024-08-04/index.md
@@ -1,0 +1,105 @@
+---
+title: "1142: 2024-08-04"
+date: 2024-08-04T09:15:00+02:00
+tags: []
+git_branch: 2024-08-04_1142
+contests: []
+words: ["great","remix","chore","power","rower","lower"]
+openers: ["great"]
+middlers: ["remix","chore","power","rower"]
+puzzles: [1142]
+hashes: ["APPAAPPAAAAAPPPACCCCACCCCCCCCC"]
+openerHashes: ["APPAA"]
+shifts: ["rvenb"]
+state: {
+  "boardState": [
+    "great",
+    "remix",
+    "chore",
+    "power",
+    "rower",
+    "lower"
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "present",
+      "present",
+      "absent",
+      "absent"
+    ],
+    [
+      "present",
+      "present",
+      "absent",
+      "absent",
+      "absent"
+    ],
+    [
+      "absent",
+      "absent",
+      "present",
+      "present",
+      "present"
+    ],
+    [
+      "absent",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    [
+      "absent",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ]
+  ],
+  "rowIndex": 6,
+  "solution": "lower",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1722755700000,
+  "lastCompletedTs": 1722755700000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 1142,
+  "dayOffset": 1142,
+  "timestamp": 1722755700
+}
+stats: {
+  "currentStreak": 11,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 13,
+    "3": 75,
+    "4": 129,
+    "5": 56,
+    "6": 38,
+    "fail": 5
+  },
+  "winPercentage": 98,
+  "gamesPlayed": 316,
+  "gamesWon": 311,
+  "averageGuesses": 4,
+  "isOnStreak": true,
+  "hasPlayed": true,
+  "lastWonDayOffset": 1142
+}
+---
+<!-- more -->
+
+**Device Context**: Screenshot taken 2024-08-04 09:15 (9:15 AM) local time. Status bar shows 9:15 with full signal and battery icons, Safari single-tabbed on nytimes.com with the purple Wordle theme. Image: 1290x2796 pixels, 3.6MP iPhone screenshot.

--- a/content/w/2024-08-05/index.md
+++ b/content/w/2024-08-05/index.md
@@ -1,0 +1,99 @@
+---
+title: "1143: 2024-08-05"
+date: 2024-08-05T08:02:00+02:00
+tags: []
+git_branch: 2024-08-05_1143
+contests: []
+words: ["claim","stone","nurse","unsee","ensue"]
+openers: ["claim"]
+middlers: ["stone","nurse","unsee"]
+puzzles: [1143]
+hashes: ["AAAAAPAAPCPPAPCPCCPCCCCCCXXXXX"]
+openerHashes: ["AAAAA"]
+shifts: ["kuado"]
+state: {
+  "boardState": [
+    "claim",
+    "stone",
+    "nurse",
+    "unsee",
+    "ensue",
+    ""
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "absent",
+      "absent",
+      "absent",
+      "absent"
+    ],
+    [
+      "present",
+      "absent",
+      "absent",
+      "present",
+      "correct"
+    ],
+    [
+      "present",
+      "present",
+      "absent",
+      "present",
+      "correct"
+    ],
+    [
+      "present",
+      "correct",
+      "correct",
+      "present",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null
+  ],
+  "rowIndex": 5,
+  "solution": "ensue",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1722837720000,
+  "lastCompletedTs": 1722837720000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 1143,
+  "dayOffset": 1143,
+  "timestamp": 1722837720
+}
+stats: {
+  "currentStreak": 12,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 13,
+    "3": 75,
+    "4": 129,
+    "5": 57,
+    "6": 38,
+    "fail": 5
+  },
+  "winPercentage": 98,
+  "gamesPlayed": 317,
+  "gamesWon": 312,
+  "averageGuesses": 4,
+  "isOnStreak": true,
+  "hasPlayed": true,
+  "lastWonDayOffset": 1143
+}
+---
+<!-- more -->
+
+**Device Context**: Screenshot taken 2024-08-05 08:02 (8:02 AM) local time. Status bar shows 8:02 with full signal and battery icons while Safari is single-tabbed on nytimes.com in the purple Wordle theme. Image: 1290x2796 pixels, 3.6MP iPhone screenshot.

--- a/content/w/2024-08-06/index.md
+++ b/content/w/2024-08-06/index.md
@@ -1,0 +1,87 @@
+---
+title: "1144: 2024-08-06"
+date: 2024-08-06T09:54:00+02:00
+tags: []
+git_branch: 2024-08-06_1144
+contests: []
+words: ["scout","diver","anvil"]
+openers: ["scout"]
+middlers: ["diver"]
+puzzles: [1144]
+hashes: ["AAAAAAPCAACCCCCXXXXXXXXXXXXXXX"]
+openerHashes: ["AAAAA"]
+shifts: ["gudrv"]
+state: {
+  "boardState": [
+    "scout",
+    "diver",
+    "anvil",
+    "",
+    "",
+    ""
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "absent",
+      "absent",
+      "absent",
+      "absent"
+    ],
+    [
+      "absent",
+      "present",
+      "correct",
+      "absent",
+      "absent"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null,
+    null,
+    null
+  ],
+  "rowIndex": 3,
+  "solution": "anvil",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1722930840000,
+  "lastCompletedTs": 1722930840000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 1144,
+  "dayOffset": 1144,
+  "timestamp": 1722930840
+}
+stats: {
+  "currentStreak": 13,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 13,
+    "3": 76,
+    "4": 129,
+    "5": 57,
+    "6": 38,
+    "fail": 5
+  },
+  "winPercentage": 98,
+  "gamesPlayed": 318,
+  "gamesWon": 313,
+  "averageGuesses": 4,
+  "isOnStreak": true,
+  "hasPlayed": true,
+  "lastWonDayOffset": 1144
+}
+---
+<!-- more -->
+
+**Device Context**: Screenshot taken 2024-08-06 09:54 (9:54 AM) local time. Status bar shows 9:54 with full signal and battery icons while Safari is single-tabbed on nytimes.com in the purple Wordle theme. Image: 1290x2796 pixels, 3.6MP iPhone screenshot.

--- a/content/w/2024-08-07/index.md
+++ b/content/w/2024-08-07/index.md
@@ -1,0 +1,99 @@
+---
+title: "1145: 2024-08-07"
+date: 2024-08-07T08:05:00+02:00
+tags: []
+git_branch: 2024-08-07_1145
+contests: []
+words: ["scout","chain","farce","wacky","macaw"]
+openers: ["scout"]
+middlers: ["chain","farce","wacky"]
+puzzles: [1145]
+hashes: ["APAAAPAPAAACAPAPCCAACCCCC"]
+openerHashes: ["APAAA"]
+shifts: ["shkjg"]
+state: {
+  "boardState": [
+    "scout",
+    "chain",
+    "farce",
+    "wacky",
+    "macaw",
+    ""
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "present",
+      "absent",
+      "absent",
+      "absent"
+    ],
+    [
+      "present",
+      "absent",
+      "present",
+      "absent",
+      "absent"
+    ],
+    [
+      "absent",
+      "correct",
+      "absent",
+      "present",
+      "absent"
+    ],
+    [
+      "present",
+      "correct",
+      "correct",
+      "absent",
+      "absent"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null
+  ],
+  "rowIndex": 5,
+  "solution": "macaw",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1723010700000,
+  "lastCompletedTs": 1723010700000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 1145,
+  "dayOffset": 1145,
+  "timestamp": 1723010700
+}
+stats: {
+  "currentStreak": 14,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 13,
+    "3": 76,
+    "4": 129,
+    "5": 58,
+    "6": 38,
+    "fail": 5
+  },
+  "winPercentage": 98,
+  "gamesPlayed": 319,
+  "gamesWon": 314,
+  "averageGuesses": 4,
+  "isOnStreak": true,
+  "hasPlayed": true,
+  "lastWonDayOffset": 1145
+}
+---
+<!-- more -->
+
+**Device Context**: Screenshot taken 2024-08-07 08:05 (8:05 AM) local time. Status bar shows 8:05 with signal, Wi-Fi, and battery icons while Safari is single-tabbed on nytimes.com in the purple Wordle theme. Image: 1290x2796 pixels, 3.6MP iPhone screenshot.

--- a/content/w/2024-08-08/index.md
+++ b/content/w/2024-08-08/index.md
@@ -1,0 +1,87 @@
+---
+title: "1146: 2024-08-08"
+date: 2024-08-08T12:07:00+02:00
+tags: []
+git_branch: 2024-08-08_1146
+contests: []
+words: ["coupe","shuck","saucy"]
+openers: ["coupe"]
+middlers: ["shuck"]
+puzzles: [1146]
+hashes: ["PACAACACCACCCCCXXXXXXXXXXXXXXX"]
+openerHashes: ["PACAA"]
+shifts: ["yhcli"]
+state: {
+  "boardState": [
+    "coupe",
+    "shuck",
+    "saucy",
+    "",
+    "",
+    ""
+  ],
+  "evaluations": [
+    [
+      "present",
+      "absent",
+      "correct",
+      "absent",
+      "absent"
+    ],
+    [
+      "correct",
+      "absent",
+      "correct",
+      "correct",
+      "absent"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null,
+    null,
+    null
+  ],
+  "rowIndex": 3,
+  "solution": "saucy",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1723111620000,
+  "lastCompletedTs": 1723111620000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 1146,
+  "dayOffset": 1146,
+  "timestamp": 1723111620
+}
+stats: {
+  "currentStreak": 15,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 13,
+    "3": 77,
+    "4": 129,
+    "5": 58,
+    "6": 38,
+    "fail": 5
+  },
+  "winPercentage": 98,
+  "gamesPlayed": 320,
+  "gamesWon": 315,
+  "averageGuesses": 4,
+  "isOnStreak": true,
+  "hasPlayed": true,
+  "lastWonDayOffset": 1146
+}
+---
+<!-- more -->
+
+**Device Context**: Screenshot taken 2024-08-08 12:07 (12:07 PM) local time. Status bar shows 12:07 with signal, Wi-Fi, and battery icons while Safari is single-tabbed on nytimes.com in the purple Wordle theme. Image: 1290x2796 pixels, 3.6MP iPhone screenshot.

--- a/content/w/2024-08-09/index.md
+++ b/content/w/2024-08-09/index.md
@@ -1,0 +1,93 @@
+---
+title: "1147: 2024-08-09"
+date: 2024-08-09T07:34:00+02:00
+tags: []
+git_branch: 2024-08-09_1147
+contests: []
+words: ["grove","mouse","outie","ounce"]
+openers: ["grove"]
+middlers: ["mouse","outie"]
+puzzles: [1147]
+hashes: ["AAPACAPPACCCAACCCCCCXXXXXXXXXX"]
+openerHashes: ["AAPAC"]
+shifts: ["ubvlo"]
+state: {
+  "boardState": [
+    "grove",
+    "mouse",
+    "outie",
+    "ounce",
+    "",
+    ""
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "absent",
+      "present",
+      "absent",
+      "correct"
+    ],
+    [
+      "absent",
+      "present",
+      "present",
+      "absent",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "absent",
+      "absent",
+      "correct"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null,
+    null
+  ],
+  "rowIndex": 4,
+  "solution": "ounce",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1723181640000,
+  "lastCompletedTs": 1723181640000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 1147,
+  "dayOffset": 1147,
+  "timestamp": 1723181640
+}
+stats: {
+  "currentStreak": 16,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 13,
+    "3": 77,
+    "4": 130,
+    "5": 58,
+    "6": 38,
+    "fail": 5
+  },
+  "winPercentage": 98,
+  "gamesPlayed": 321,
+  "gamesWon": 316,
+  "averageGuesses": 4,
+  "isOnStreak": true,
+  "hasPlayed": true,
+  "lastWonDayOffset": 1147
+}
+---
+<!-- more -->
+
+**Device Context**: Screenshot taken 2024-08-09 07:34 (7:34 AM) local time. Status bar shows 7:34 with signal, Wi-Fi, and battery icons while Safari is single-tabbed on nytimes.com in the purple Wordle theme. Image: 1290x2796 pixels, 3.6MP iPhone screenshot.

--- a/content/w/2024-08-10/index.md
+++ b/content/w/2024-08-10/index.md
@@ -1,0 +1,99 @@
+---
+title: "1148: 2024-08-10"
+date: 2024-08-10T07:51:00+02:00
+tags: []
+git_branch: 2024-08-10_1148
+contests: []
+words: ["group","faces","chewy","evict","medic"]
+openers: ["group"]
+middlers: ["faces","chewy","evict"]
+puzzles: [1148]
+hashes: ["AAAAAAAPPAPAPAAPAPPACCCCCXXXXX"]
+openerHashes: ["AAAAA"]
+shifts: ["sllrm"]
+state: {
+  "boardState": [
+    "group",
+    "faces",
+    "chewy",
+    "evict",
+    "medic",
+    ""
+  ],
+  "evaluations": [
+    [
+      "absent",
+      "absent",
+      "absent",
+      "absent",
+      "absent"
+    ],
+    [
+      "absent",
+      "absent",
+      "present",
+      "present",
+      "absent"
+    ],
+    [
+      "present",
+      "absent",
+      "present",
+      "absent",
+      "absent"
+    ],
+    [
+      "present",
+      "absent",
+      "present",
+      "present",
+      "absent"
+    ],
+    [
+      "correct",
+      "correct",
+      "correct",
+      "correct",
+      "correct"
+    ],
+    null
+  ],
+  "rowIndex": 5,
+  "solution": "medic",
+  "gameStatus": "WIN",
+  "lastPlayedTs": 1723269060000,
+  "lastCompletedTs": 1723269060000,
+  "hardMode": true,
+  "settings": {
+    "hardMode": true,
+    "darkMode": true,
+    "colorblindMode": false
+  },
+  "gameId": 1148,
+  "dayOffset": 1148,
+  "timestamp": 1723269060
+}
+stats: {
+  "currentStreak": 17,
+  "maxStreak": 36,
+  "guesses": {
+    "1": 0,
+    "2": 13,
+    "3": 77,
+    "4": 130,
+    "5": 59,
+    "6": 38,
+    "fail": 5
+  },
+  "winPercentage": 98,
+  "gamesPlayed": 322,
+  "gamesWon": 317,
+  "averageGuesses": 4,
+  "isOnStreak": true,
+  "hasPlayed": true,
+  "lastWonDayOffset": 1148
+}
+---
+<!-- more -->
+
+**Device Context**: Screenshot taken 2024-08-10 07:51 (7:51 AM) local time. Status bar shows 7:51 with signal, Wi-Fi, and battery icons while Safari is single-tabbed on nytimes.com in the purple Wordle theme. Image: 1290x2796 pixels, 3.6MP iPhone screenshot.


### PR DESCRIPTION
## Summary
- add the August 10, 2024 Wordle puzzle with Stockholm-local timestamp and git branch metadata
- record the group→faces→chewy→evict→medic solve path, board evaluations, and updated streak statistics
- document the 07:51 CEST device context from the provided screenshot

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d950a984388323846ce12cf2e71455