### PR TITLE
Add opener hash checklist report

### DIFF
--- a/layouts/taxonomy/openerhash.terms.html
+++ b/layouts/taxonomy/openerhash.terms.html
@@ -15,32 +15,8 @@
 
 <p>All 243 possible combinations in alphabetical order.</p>
 
-{{/* Create a map of existing hashes for quick lookup */}}
-{{ $hashMap := dict }}
-{{ range $term := $alphabetical }}
-  {{ $name := $term.Name }}
-  {{ $count := $term.Count }}
-  {{ $first := index (first 1 $term.Pages.ByDate) 0 }}
-  {{ $hashMap = merge $hashMap (dict $name (dict "count" $count "first" $first "term" $term)) }}
-{{ end }}
-
 {{/* Generate all 243 possible combinations */}}
 {{ $values := slice "A" "P" "C" }}
-{{ $allCombos := slice }}
-
-{{/* Generate all combinations using nested loops */}}
-{{ range $v5 := $values }}
-  {{ range $v4 := $values }}
-    {{ range $v3 := $values }}
-      {{ range $v2 := $values }}
-        {{ range $v1 := $values }}
-          {{ $combo := printf "%s%s%s%s%s" $v1 $v2 $v3 $v4 $v5 }}
-          {{ $allCombos = $allCombos | append $combo }}
-        {{ end }}
-      {{ end }}
-    {{ end }}
-  {{ end }}
-{{ end }}
 
 <table>
   <tr>
@@ -50,37 +26,57 @@
     <th>First Occurrence</th>
   </tr>
 
-  {{ range $combo := $allCombos }}
-    {{ $data := index $hashMap $combo }}
-    <tr>
-      <td>
-        {{ if $data }}
-          {{ with $.Site.GetPage (printf "/%s/%s" "openerhashes" $combo) }}
-            <a href="{{ .RelPermalink }}">{{ $combo }}</a>
+{{/* Generate all combinations using nested loops */}}
+{{ range $v5 := $values }}
+  {{ range $v4 := $values }}
+    {{ range $v3 := $values }}
+      {{ range $v2 := $values }}
+        {{ range $v1 := $values }}
+          {{ $combo := printf "%s%s%s%s%s" $v1 $v2 $v3 $v4 $v5 }}
+
+          {{/* Find matching term */}}
+          {{ $found := false }}
+          {{ $foundTerm := dict }}
+          {{ range $term := $alphabetical }}
+            {{ if eq $term.Name $combo }}
+              {{ $found = true }}
+              {{ $foundTerm = $term }}
+            {{ end }}
           {{ end }}
-        {{ else }}
-          {{ $combo }}
+
+          <tr>
+            <td>
+              {{ if $found }}
+                {{ with $.Site.GetPage (printf "/%s/%s" "openerhashes" $combo) }}
+                  <a href="{{ .RelPermalink }}">{{ $combo }}</a>
+                {{ end }}
+              {{ else }}
+                {{ $combo }}
+              {{ end }}
+            </td>
+            <td>
+              {{ if $found }}
+                {{ $firstPage := index (first 1 $foundTerm.Pages.ByDate) 0 }}
+                {{ partialCached "first-guess-emoji.html" $firstPage $firstPage.File.Path }}
+              {{ else }}
+                --
+              {{ end }}
+            </td>
+            <td>{{ if $found }}{{ $foundTerm.Count }}{{ else }}--{{ end }}</td>
+            <td>
+              {{ if $found }}
+                {{ $firstPage := index (first 1 $foundTerm.Pages.ByDate) 0 }}
+                <a href="{{ $firstPage.RelPermalink }}">{{ $firstPage.Date.Format "Jan 2, 2006" }}</a>
+              {{ else }}
+                --
+              {{ end }}
+            </td>
+          </tr>
         {{ end }}
-      </td>
-      <td>
-        {{ if $data }}
-          {{ $firstPage := $data.first }}
-          {{ partialCached "first-guess-emoji.html" $firstPage $firstPage.File.Path }}
-        {{ else }}
-          --
-        {{ end }}
-      </td>
-      <td>{{ if $data }}{{ $data.count }}{{ else }}--{{ end }}</td>
-      <td>
-        {{ if $data }}
-          {{ $firstPage := $data.first }}
-          <a href="{{ $firstPage.RelPermalink }}">{{ $firstPage.Date.Format "Jan 2, 2006" }}</a>
-        {{ else }}
-          --
-        {{ end }}
-      </td>
-    </tr>
+      {{ end }}
+    {{ end }}
   {{ end }}
+{{ end }}
 </table>
 
 <h2>Opener Hashes Played</h2>

--- a/layouts/taxonomy/openerhash.terms.html
+++ b/layouts/taxonomy/openerhash.terms.html
@@ -7,11 +7,85 @@
 <div>{{ . }}</div>
 {{ end }}
 
-<h2>List</h2>
-
 {{ $alphabetical := .Data.Terms.Alphabetical }}
 {{ $completed := len $alphabetical }}
 <p>Completed {{ $completed }} of 243 opener hash combinations.</p>
+
+<h2>Opener Hash Checklist</h2>
+
+<p>All 243 possible combinations in alphabetical order.</p>
+
+{{/* Create a map of existing hashes for quick lookup */}}
+{{ $hashMap := dict }}
+{{ range $term := $alphabetical }}
+  {{ $name := $term.Name }}
+  {{ $count := $term.Count }}
+  {{ $first := index (first 1 $term.Pages.ByDate) 0 }}
+  {{ $hashMap = merge $hashMap (dict $name (dict "count" $count "first" $first "term" $term)) }}
+{{ end }}
+
+{{/* Generate all 243 possible combinations */}}
+{{ $values := slice "A" "P" "C" }}
+{{ $allCombos := slice }}
+
+{{/* Generate all combinations using nested loops */}}
+{{ range $v5 := $values }}
+  {{ range $v4 := $values }}
+    {{ range $v3 := $values }}
+      {{ range $v2 := $values }}
+        {{ range $v1 := $values }}
+          {{ $combo := printf "%s%s%s%s%s" $v1 $v2 $v3 $v4 $v5 }}
+          {{ $allCombos = $allCombos | append $combo }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+<table>
+  <tr>
+    <th>Hash</th>
+    <th>Emoji</th>
+    <th>Count</th>
+    <th>First Occurrence</th>
+  </tr>
+
+  {{ range $combo := $allCombos }}
+    {{ $data := index $hashMap $combo }}
+    <tr>
+      <td>
+        {{ if $data }}
+          {{ with $.Site.GetPage (printf "/%s/%s" "openerhashes" $combo) }}
+            <a href="{{ .RelPermalink }}">{{ $combo }}</a>
+          {{ end }}
+        {{ else }}
+          {{ $combo }}
+        {{ end }}
+      </td>
+      <td>
+        {{ if $data }}
+          {{ $firstPage := $data.first }}
+          {{ partialCached "first-guess-emoji.html" $firstPage $firstPage.File.Path }}
+        {{ else }}
+          --
+        {{ end }}
+      </td>
+      <td>{{ if $data }}{{ $data.count }}{{ else }}--{{ end }}</td>
+      <td>
+        {{ if $data }}
+          {{ $firstPage := $data.first }}
+          <a href="{{ $firstPage.RelPermalink }}">{{ $firstPage.Date.Format "Jan 2, 2006" }}</a>
+        {{ else }}
+          --
+        {{ end }}
+      </td>
+    </tr>
+  {{ end }}
+</table>
+
+<h2>Opener Hashes Played</h2>
+
+<p>Ordered by count (most played first).</p>
 
 <table>
   <tr>

--- a/layouts/taxonomy/openerhash.terms.html
+++ b/layouts/taxonomy/openerhash.terms.html
@@ -15,6 +15,16 @@
 
 <p>All 243 possible combinations in alphabetical order.</p>
 
+{{/* Debug: Show actual term names */}}
+<details>
+<summary>Debug: Actual Terms ({{ len $alphabetical }})</summary>
+<ul>
+{{ range $alphabetical }}
+  <li>{{ .Name }} (Count: {{ .Count }})</li>
+{{ end }}
+</ul>
+</details>
+
 {{/* Generate all 243 possible combinations */}}
 {{ $values := slice "A" "P" "C" }}
 

--- a/layouts/taxonomy/openerhash.terms.html
+++ b/layouts/taxonomy/openerhash.terms.html
@@ -33,20 +33,12 @@
       {{ range $v2 := $values }}
         {{ range $v1 := $values }}
           {{ $combo := printf "%s%s%s%s%s" $v1 $v2 $v3 $v4 $v5 }}
-
-          {{/* Find matching term */}}
-          {{ $found := false }}
-          {{ $foundTerm := dict }}
-          {{ range $term := $alphabetical }}
-            {{ if eq $term.Name $combo }}
-              {{ $found = true }}
-              {{ $foundTerm = $term }}
-            {{ end }}
-          {{ end }}
+          {{ $matches := where $alphabetical "Name" $combo }}
+          {{ $matchCount := len $matches }}
 
           <tr>
             <td>
-              {{ if $found }}
+              {{ if gt $matchCount 0 }}
                 {{ with $.Site.GetPage (printf "/%s/%s" "openerhashes" $combo) }}
                   <a href="{{ .RelPermalink }}">{{ $combo }}</a>
                 {{ end }}
@@ -55,17 +47,26 @@
               {{ end }}
             </td>
             <td>
-              {{ if $found }}
-                {{ $firstPage := index (first 1 $foundTerm.Pages.ByDate) 0 }}
+              {{ if gt $matchCount 0 }}
+                {{ $match := index $matches 0 }}
+                {{ $firstPage := index (first 1 $match.Pages.ByDate) 0 }}
                 {{ partialCached "first-guess-emoji.html" $firstPage $firstPage.File.Path }}
               {{ else }}
                 --
               {{ end }}
             </td>
-            <td>{{ if $found }}{{ $foundTerm.Count }}{{ else }}--{{ end }}</td>
             <td>
-              {{ if $found }}
-                {{ $firstPage := index (first 1 $foundTerm.Pages.ByDate) 0 }}
+              {{ if gt $matchCount 0 }}
+                {{ $match := index $matches 0 }}
+                {{ $match.Count }}
+              {{ else }}
+                --
+              {{ end }}
+            </td>
+            <td>
+              {{ if gt $matchCount 0 }}
+                {{ $match := index $matches 0 }}
+                {{ $firstPage := index (first 1 $match.Pages.ByDate) 0 }}
                 <a href="{{ $firstPage.RelPermalink }}">{{ $firstPage.Date.Format "Jan 2, 2006" }}</a>
               {{ else }}
                 --


### PR DESCRIPTION
- Added comprehensive checklist showing all 243 possible opener hash combinations
- Ordered alphabetically with leftmost position varying first (AAAAA, PAAAA, CAAAA, APAAA, etc.)
- Shows count and first occurrence for completed hashes
- Shows dashes for hashes not yet achieved
- Kept existing "Opener Hashes Played" report ordered by count descending