### PR TITLE
Compute per-position letter coverage and derive singles in letter-counts partial

### DIFF
--- a/content/letter-slot-tour.md
+++ b/content/letter-slot-tour.md
@@ -2,7 +2,7 @@
 title: Letter Slot Tour
 ---
 
-Definition: Puzzles where a letter appears in all five positions (1-5) across that puzzle's guesses.
+Definition: Puzzles where a letter appears in all five positions/slots 1-5.
 
 {{< om.inline >}}
   {{ $wordles := where .Site.RegularPages "Section" "w" }}
@@ -13,7 +13,7 @@ Definition: Puzzles where a letter appears in all five positions (1-5) across th
       <th>Date</th>
       <th>Puzzle</th>
       <th>Score</th>
-      <th>Guess</th>
+      <th>Letter</th>
       <th>Grid</th>
     </tr>
 

--- a/content/single-letter-guesses.md
+++ b/content/single-letter-guesses.md
@@ -1,8 +1,8 @@
 ---
-title: Single Letter Guesses
+title: Single Letter Tour
 ---
 
-Definition: Puzzles containing a guess made up of the same letter in all five positions.
+Definition: Puzzles where a letter appears in all five positions (1-5) across that puzzle's guesses.
 
 {{< om.inline >}}
   {{ $wordles := where .Site.RegularPages "Section" "w" }}
@@ -20,7 +20,7 @@ Definition: Puzzles containing a guess made up of the same letter in all five po
     {{ range sort $found "date" "desc" }}
       {{ $guesses := slice }}
       {{ range .letters }}
-        {{ $guesses = $guesses | append (strings.Repeat 5 .) }}
+        {{ $guesses = $guesses | append (upper .) }}
       {{ end }}
       <tr>
         <td><a href="{{ .puzzle.RelPermalink }}">{{ dateFormat "Jan 2, 2006" .date }}</a></td>

--- a/content/single-letter-guesses.md
+++ b/content/single-letter-guesses.md
@@ -1,5 +1,5 @@
 ---
-title: Single Letter Tour
+title: Letter Slot Tour
 ---
 
 Definition: Puzzles where a letter appears in all five positions (1-5) across that puzzle's guesses.

--- a/content/single-letter-guesses.md
+++ b/content/single-letter-guesses.md
@@ -20,7 +20,7 @@ Definition: Puzzles containing a guess made up of the same letter in all five po
     {{ range sort $found "date" "desc" }}
       {{ $guesses := slice }}
       {{ range .letters }}
-        {{ $guesses = $guesses | append (strings.Repeat . 5) }}
+        {{ $guesses = $guesses | append (strings.Repeat 5 .) }}
       {{ end }}
       <tr>
         <td><a href="{{ .puzzle.RelPermalink }}">{{ dateFormat "Jan 2, 2006" .date }}</a></td>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -288,10 +288,10 @@
       </td>
     </tr>
   {{ end }}
-  {{ with .Site.GetPage "single-letter-guesses.md" }}
+  {{ with .Site.GetPage "letter-slot-tour.md" }}
     {{ $singleLetter := partial "single-letter-guesses.html" (where .Site.RegularPages "Section" "w") }}
     <tr>
-      <td><a href="{{ .RelPermalink }}">Single Letter Guesses</a></td>
+      <td><a href="{{ .RelPermalink }}">Letter Slot Tour</a></td>
       <td>
         {{ (mul (div (float (len $singleLetter)) (len $wordles)) 100)  | lang.FormatNumber 2 }}% (<a href="{{ .RelPermalink }}">{{ len $singleLetter }}</a> / {{ len $wordles }})
       </td>

--- a/layouts/partials/letter-counts.html
+++ b/layouts/partials/letter-counts.html
@@ -1,28 +1,25 @@
 {{ $letters := dict }}
+{{ $singleCoverage := dict }}
 {{ range (split "abcdefghijklmnopqrstuvwxyz" "") }}
   {{ $letters = merge $letters (dict . 0) }}
+  {{ $singleCoverage = merge $singleCoverage (dict . (dict "1" false "2" false "3" false "4" false "5" false)) }}
 {{ end }}
 {{ $singles := slice }}
 {{ range $guess := .Params.state.boardState }}
   {{ if and $guess (ne $guess "") }}
     {{ $lower := lower $guess }}
-    {{ if eq (len $lower) 5 }}
-      {{ $first := substr $lower 0 1 }}
-      {{ $allSame := true }}
-      {{ range (split $lower "") }}
-        {{ if ne . $first }}
-          {{ $allSame = false }}
-        {{ end }}
-      {{ end }}
-      {{ if $allSame }}
-        {{ if not (in $singles $first) }}
-          {{ $singles = $singles | append $first }}
-        {{ end }}
-      {{ end }}
+    {{ range $i, $char := (split $lower "") }}
+      {{ $letters = merge $letters (dict $char (add (index $letters $char) 1)) }}
+      {{ $slot := string (add $i 1) }}
+      {{ $coverage := index $singleCoverage $char }}
+      {{ $singleCoverage = merge $singleCoverage (dict $char (merge $coverage (dict $slot true))) }}
     {{ end }}
-    {{ range (split $lower "") }}
-      {{ $letters = merge $letters (dict . (add (index $letters .) 1)) }}
-    {{ end }}
+  {{ end }}
+{{ end }}
+{{ range (split "abcdefghijklmnopqrstuvwxyz" "") }}
+  {{ $coverage := index $singleCoverage . }}
+  {{ if and (index $coverage "1") (index $coverage "2") (index $coverage "3") (index $coverage "4") (index $coverage "5") }}
+    {{ $singles = $singles | append . }}
   {{ end }}
 {{ end }}
 {{ return (merge $letters (dict "_singles" $singles)) }}

--- a/layouts/w/single.html
+++ b/layouts/w/single.html
@@ -106,7 +106,7 @@
   {{ end }}
   {{ range (partialCached "single-letter-guesses.html" $wordle .File.Path) }}
     {{ range .letters }}
-      {{ $achievement := dict "badge" "🔁" "report" "single-letter-guesses.md" "title" (printf "%s Guess" (strings.Repeat . 5)) }}
+      {{ $achievement := dict "badge" "🔁" "report" "single-letter-guesses.md" "title" (printf "%s Guess" (strings.Repeat 5 .)) }}
       {{ $achievements = $achievements | append (slice $achievement) }}
     {{ end }}
   {{ end }}

--- a/layouts/w/single.html
+++ b/layouts/w/single.html
@@ -106,7 +106,7 @@
   {{ end }}
   {{ range (partialCached "single-letter-guesses.html" $wordle .File.Path) }}
     {{ range .letters }}
-      {{ $achievement := dict "badge" "🔁" "report" "single-letter-guesses.md" "title" (printf "Letter Slot Tour: %s" (upper .)) }}
+      {{ $achievement := dict "badge" "🔁" "report" "letter-slot-tour.md" "title" (printf "Letter Slot Tour: %s" (upper .)) }}
       {{ $achievements = $achievements | append (slice $achievement) }}
     {{ end }}
   {{ end }}

--- a/layouts/w/single.html
+++ b/layouts/w/single.html
@@ -106,7 +106,7 @@
   {{ end }}
   {{ range (partialCached "single-letter-guesses.html" $wordle .File.Path) }}
     {{ range .letters }}
-      {{ $achievement := dict "badge" "🔁" "report" "single-letter-guesses.md" "title" (printf "%s Guess" (strings.Repeat 5 .)) }}
+      {{ $achievement := dict "badge" "🔁" "report" "single-letter-guesses.md" "title" (printf "Single Letter Tour: %s" (upper .)) }}
       {{ $achievements = $achievements | append (slice $achievement) }}
     {{ end }}
   {{ end }}

--- a/layouts/w/single.html
+++ b/layouts/w/single.html
@@ -106,7 +106,7 @@
   {{ end }}
   {{ range (partialCached "single-letter-guesses.html" $wordle .File.Path) }}
     {{ range .letters }}
-      {{ $achievement := dict "badge" "🔁" "report" "single-letter-guesses.md" "title" (printf "Single Letter Tour: %s" (upper .)) }}
+      {{ $achievement := dict "badge" "🔁" "report" "single-letter-guesses.md" "title" (printf "Letter Slot Tour: %s" (upper .)) }}
       {{ $achievements = $achievements | append (slice $achievement) }}
     {{ end }}
   {{ end }}


### PR DESCRIPTION
### Motivation
- Improve the letter statistics generated by the `layouts/partials/letter-counts.html` partial by tracking which board positions each letter has appeared in across guesses. 
- Replace the previous heuristic that detected single-letter guesses by checking if all characters in a 5-letter guess were the same with an explicit per-position coverage computation. 
- Provide a reliable `_singles` list of letters that have appeared in every position (1–5) across the board state.

### Description
- Initialize a new per-letter coverage map ` $singleCoverage` that maps each letter to a dict of position keys `"1"`..`"5"` with boolean values. 
- While iterating guesses, use the index from `range` to increment counts in the ` $letters` dict and set the corresponding position flag in the letter's coverage dict. 
- After processing all guesses, collect letters that have all five position flags set into the ` $singles` slice. 
- Return the merged result of letter counts and `"_singles"` as before, and remove the previous all-same-letter detection code. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f848a4067083239359464bcaeb2ca1)