### PR TITLE
Add Double Letter Slot Tour rarity and cached detection

### DIFF
--- a/content/double-letter-slot-tour.md
+++ b/content/double-letter-slot-tour.md
@@ -1,32 +1,28 @@
 ---
-title: Letter Slot Tour
+title: Double Letter Slot Tour
 ---
 
-Definition: Puzzles where a letter appears in all five positions/slots 1-5 across all guesses.
+Definition: Puzzles where two letters each appear in all five positions/slots 1-5 across all guesses.
 
 {{< om.inline >}}
   {{ $wordles := where .Site.RegularPages "Section" "w" }}
-  {{ $found := partial "single-letter-guesses.html" $wordles }}
+  {{ $found := partial "double-letter-guesses.html" $wordles }}
   <p>Pct of Total: <strong>{{ (mul (div (float (len $found)) (len $wordles)) 100)  | lang.FormatNumber 2 }}% ({{ len $found }} / {{ len $wordles }})</strong></p>
   <table>
     <tr>
       <th>Date</th>
       <th>Puzzle</th>
       <th>Score</th>
-      <th>Letter</th>
+      <th>Letters</th>
       <th>Grid</th>
     </tr>
 
     {{ range sort $found "date" "desc" }}
-      {{ $guesses := slice }}
-      {{ range .letters }}
-        {{ $guesses = $guesses | append (upper .) }}
-      {{ end }}
       <tr>
         <td><a href="{{ .puzzle.RelPermalink }}">{{ dateFormat "Jan 2, 2006" .date }}</a></td>
         <td><a href="{{ .puzzle.RelPermalink }}">{{ index .puzzle.Params.puzzles 0 }}</a></td>
         <td><a href="{{ .puzzle.RelPermalink }}">{{ partialCached "puzzle-score.html" .puzzle .puzzle.File.Path }}</a></td>
-        <td>{{ delimit $guesses ", " }}</td>
+        <td>{{ delimit .letters ", " | upper }}</td>
         <td>{{ partialCached "emoji-grid" .puzzle .puzzle.File.Path }}</td>
       </tr>
     {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -289,11 +289,20 @@
     </tr>
   {{ end }}
   {{ with .Site.GetPage "letter-slot-tour.md" }}
-    {{ $singleLetter := partial "single-letter-guesses.html" (where .Site.RegularPages "Section" "w") }}
+    {{ $singleLetter := partialCached "single-letter-guesses.html" (where .Site.RegularPages "Section" "w") "single-letter-guesses" }}
     <tr>
       <td><a href="{{ .RelPermalink }}">Letter Slot Tour</a></td>
       <td>
         {{ (mul (div (float (len $singleLetter)) (len $wordles)) 100)  | lang.FormatNumber 2 }}% (<a href="{{ .RelPermalink }}">{{ len $singleLetter }}</a> / {{ len $wordles }})
+      </td>
+    </tr>
+  {{ end }}
+  {{ with .Site.GetPage "double-letter-slot-tour.md" }}
+    {{ $doubleLetter := partialCached "double-letter-guesses.html" (where .Site.RegularPages "Section" "w") "double-letter-guesses" }}
+    <tr>
+      <td><a href="{{ .RelPermalink }}">Double Letter Slot Tour</a></td>
+      <td>
+        {{ (mul (div (float (len $doubleLetter)) (len $wordles)) 100)  | lang.FormatNumber 2 }}% (<a href="{{ .RelPermalink }}">{{ len $doubleLetter }}</a> / {{ len $wordles }})
       </td>
     </tr>
   {{ end }}

--- a/layouts/index.p8s.txt
+++ b/layouts/index.p8s.txt
@@ -33,3 +33,4 @@ total_rarities_back_half_alphabet_pangrams {{ len (partialCached "back-half-alph
 total_rarities_all_vowels {{ len (partialCached "all-vowels.html" $wordles) }}
 total_rarities_all_vowels_plus_y {{ len (partialCached "all-vowels-plus-y.html" $wordles) }}
 total_rarities_single_letter_guesses {{ len (partialCached "single-letter-guesses.html" $wordles) }}
+total_rarities_double_letter_guesses {{ len (partialCached "double-letter-guesses.html" $wordles "double-letter-guesses") }}

--- a/layouts/partials/double-letter-guesses.html
+++ b/layouts/partials/double-letter-guesses.html
@@ -1,0 +1,9 @@
+{{ $found := slice }}
+{{ range . }}
+  {{ $letters := partialCached "letter-counts.html" . .File.Path }}
+  {{ $doubles := index $letters "_doubles" }}
+  {{ if gt (len $doubles) 0 }}
+    {{ $found = $found | append (dict "date" .Date "puzzle" . "letters" $doubles) }}
+  {{ end }}
+{{ end }}
+{{ return $found }}

--- a/layouts/partials/letter-counts.html
+++ b/layouts/partials/letter-counts.html
@@ -5,6 +5,7 @@
   {{ $singleCoverage = merge $singleCoverage (dict . (dict "1" false "2" false "3" false "4" false "5" false)) }}
 {{ end }}
 {{ $singles := slice }}
+{{ $doubles := slice }}
 {{ range $guess := .Params.state.boardState }}
   {{ if and $guess (ne $guess "") }}
     {{ $lower := lower $guess }}
@@ -22,4 +23,9 @@
     {{ $singles = $singles | append . }}
   {{ end }}
 {{ end }}
-{{ return (merge $letters (dict "_singles" $singles)) }}
+{{ range $i, $left := $singles }}
+  {{ range after (add $i 1) $singles }}
+    {{ $doubles = $doubles | append (printf "%s%s" $left .) }}
+  {{ end }}
+{{ end }}
+{{ return (merge $letters (dict "_singles" $singles "_doubles" $doubles)) }}

--- a/layouts/w/single.html
+++ b/layouts/w/single.html
@@ -110,6 +110,12 @@
       {{ $achievements = $achievements | append (slice $achievement) }}
     {{ end }}
   {{ end }}
+  {{ range (partialCached "double-letter-guesses.html" $wordle .File.Path) }}
+    {{ range .letters }}
+      {{ $achievement := dict "badge" "🔂" "report" "double-letter-slot-tour.md" "title" (printf "Double Letter Slot Tour: %s" (upper .)) }}
+      {{ $achievements = $achievements | append (slice $achievement) }}
+    {{ end }}
+  {{ end }}
   {{ with (partialCached "stairstep" . .File.Path) }}
     {{ $achievement := dict "badge" "🪜" "report" "stairstep.md" "title" "Stairstep" }}
     {{ $achievements = $achievements | append (slice $achievement) }}


### PR DESCRIPTION
### Motivation
- Add a new derived rarity for puzzles that tour two letters (both letters appear in slots 1–5 across all guesses) and expose it in the reports and per-puzzle achievements. 
- Reuse the existing single-letter slot coverage work so double detection is efficient and cache-friendly.

### Description
- Added a new report page `content/double-letter-slot-tour.md` that lists puzzles with double-letter slot tours and clarifies the definition as coverage "across all guesses". 
- Extended `layouts/partials/letter-counts.html` to compute a `_doubles` list by combining already-detected `_singles`, avoiding a second scan of guess data. 
- Added a new partial `layouts/partials/double-letter-guesses.html` that returns puzzles containing one or more double-letter tours. 
- Wired the new rarity into the homepage (`layouts/index.html`), per-puzzle achievements (`layouts/w/single.html`) with badge `🔂`, and p8s metrics output (`layouts/index.p8s.txt`), and clarified the `letter-slot-tour` page text. 
- Use `partialCached` for aggregating both single and double lists so results are cached and lookups are efficient.

### Testing
- Ran the unit test `node static/tools/enhance/enrich-emoji.test.js` and it completed successfully. 
- Attempted a Hugo build; `asdf exec hugo` failed in this environment because `asdf` is unavailable, and `hugo --templateMetrics` was started but did not complete within the execution timeframe. 
- Verified templates and partials were updated and the new pages/partials were added (`content/double-letter-slot-tour.md`, `layouts/partials/double-letter-guesses.html`, and `layouts/partials/letter-counts.html`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f932d4d6fc8323ae912e852db45c14)