### PR TITLE
Add newest words widget and full list page

### DIFF
--- a/content/newest-words.md
+++ b/content/newest-words.md
@@ -5,8 +5,7 @@ title: Newest Words
 Words sorted by when they were first used, newest additions first.
 
 {{< nw.inline >}}
-  {{ $wordles := where .Site.RegularPages "Section" "w" }}
-  {{ $newestWords := partialCached "newest-words.html" $wordles "newest-words" }}
+  {{ $newestWords := partialCached "newest-words.html" .Site "newest-words" }}
 
   <p>Total Distinct Words: <strong>{{ len $newestWords }}</strong></p>
 

--- a/content/newest-words.md
+++ b/content/newest-words.md
@@ -1,0 +1,26 @@
+---
+title: Newest Words
+---
+
+Words sorted by when they were first used, newest additions first.
+
+{{< nw.inline >}}
+  {{ $wordles := where .Site.RegularPages "Section" "w" }}
+  {{ $newestWords := partialCached "newest-words.html" $wordles "newest-words" }}
+
+  <p>Total Distinct Words: <strong>{{ len $newestWords }}</strong></p>
+
+  <table>
+    <tr>
+      <th>Word</th>
+      <th>First Used</th>
+    </tr>
+    {{ range $newestWords }}
+      {{ $nw := . }}
+      <tr>
+        <td>{{ with $.Site.GetPage (printf "/words/%s" $nw.word) }}<a href="{{ .RelPermalink }}">{{ $nw.word }}</a>{{ else }}{{ $nw.word }}{{ end }}</td>
+        <td><a href="{{ $nw.firstPage.RelPermalink }}">{{ $nw.firstDate.Format "Jan 2, 2006" }}</a></td>
+      </tr>
+    {{ end }}
+  </table>
+{{< /nw.inline >}}

--- a/content/newest-words.md
+++ b/content/newest-words.md
@@ -13,12 +13,16 @@ Words sorted by when they were first used, newest additions first.
     <tr>
       <th>Word</th>
       <th>First Used</th>
+      <th>Last Used</th>
+      <th>Uses</th>
     </tr>
     {{ range $newestWords }}
       {{ $nw := . }}
       <tr>
         <td>{{ with $.Site.GetPage (printf "/words/%s" $nw.word) }}<a href="{{ .RelPermalink }}">{{ $nw.word }}</a>{{ else }}{{ $nw.word }}{{ end }}</td>
         <td><a href="{{ $nw.firstPage.RelPermalink }}">{{ $nw.firstDate.Format "Jan 2, 2006" }}</a></td>
+        <td><a href="{{ $nw.lastPage.RelPermalink }}">{{ $nw.lastDate.Format "Jan 2, 2006" }}</a></td>
+        <td>{{ $nw.count }}</td>
       </tr>
     {{ end }}
   </table>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -402,7 +402,7 @@
 </table>
 <p><a href="{{ with .Site.GetPage "non-opener-usage.md" }}{{ .RelPermalink }}{{ end }}">Full list…</a></p>
 
-{{ $newestWords := partialCached "newest-words.html" $wordles "newest-words" }}
+{{ $newestWords := partialCached "newest-words.html" .Site "newest-words" }}
 <h2>🆕 Newest Words</h2>
 <table>
   <tr>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -402,6 +402,23 @@
 </table>
 <p><a href="{{ with .Site.GetPage "non-opener-usage.md" }}{{ .RelPermalink }}{{ end }}">Full list…</a></p>
 
+{{ $newestWords := partialCached "newest-words.html" $wordles "newest-words" }}
+<h2>🆕 Newest Words</h2>
+<table>
+  <tr>
+    <th>Word</th>
+    <th>First Used</th>
+  </tr>
+  {{ range first 10 $newestWords }}
+    {{ $nw := . }}
+    <tr>
+      <td>{{ with $.Site.GetPage (printf "/words/%s" $nw.word) }}<a href="{{ .RelPermalink }}">{{ $nw.word }}</a>{{ else }}{{ $nw.word }}{{ end }}</td>
+      <td><a href="{{ $nw.firstPage.RelPermalink }}">{{ $nw.firstDate.Format "Jan 2, 2006" }}</a></td>
+    </tr>
+  {{ end }}
+</table>
+<p><a href="{{ with .Site.GetPage "newest-words.md" }}{{ .RelPermalink }}{{ end }}">Full list…</a></p>
+
 <h2>🗓 Monthly Trends</h2>
 <table>
   <tr>

--- a/layouts/partials/newest-words.html
+++ b/layouts/partials/newest-words.html
@@ -1,0 +1,23 @@
+{{ $wordFirstSeen := dict }}
+
+{{ range (sort . "Date" "asc") }}
+  {{ $page := . }}
+  {{ $words := .Params.words }}
+  {{ if not $words }}
+    {{ $words = index .Params.state "boardState" }}
+  {{ end }}
+  {{ range $words }}
+    {{ if . }}
+      {{ if not (isset $wordFirstSeen .) }}
+        {{ $wordFirstSeen = merge $wordFirstSeen (dict . $page) }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ $result := slice }}
+{{ range $word, $page := $wordFirstSeen }}
+  {{ $result = $result | append (dict "word" $word "firstDate" $page.Date "firstPage" $page) }}
+{{ end }}
+
+{{ return (sort $result "firstDate" "desc") }}

--- a/layouts/partials/newest-words.html
+++ b/layouts/partials/newest-words.html
@@ -1,9 +1,11 @@
 {{ $result := slice }}
 
 {{ range $word, $weightedPages := .Taxonomies.words }}
-  {{ $first := index (first 1 $weightedPages.Pages.ByDate) 0 }}
+  {{ $sorted := $weightedPages.Pages.ByDate }}
+  {{ $first := index (first 1 $sorted) 0 }}
+  {{ $last := index (last 1 $sorted) 0 }}
   {{ if $first }}
-    {{ $result = $result | append (dict "word" $word "firstDate" $first.Date "firstPage" $first) }}
+    {{ $result = $result | append (dict "word" $word "firstDate" $first.Date "firstPage" $first "lastDate" $last.Date "lastPage" $last "count" (len $weightedPages)) }}
   {{ end }}
 {{ end }}
 

--- a/layouts/partials/newest-words.html
+++ b/layouts/partials/newest-words.html
@@ -1,23 +1,10 @@
-{{ $wordFirstSeen := dict }}
-
-{{ range (sort . "Date" "asc") }}
-  {{ $page := . }}
-  {{ $words := .Params.words }}
-  {{ if not $words }}
-    {{ $words = index .Params.state "boardState" }}
-  {{ end }}
-  {{ range $words }}
-    {{ if . }}
-      {{ if not (isset $wordFirstSeen .) }}
-        {{ $wordFirstSeen = merge $wordFirstSeen (dict . $page) }}
-      {{ end }}
-    {{ end }}
-  {{ end }}
-{{ end }}
-
 {{ $result := slice }}
-{{ range $word, $page := $wordFirstSeen }}
-  {{ $result = $result | append (dict "word" $word "firstDate" $page.Date "firstPage" $page) }}
+
+{{ range $word, $weightedPages := .Taxonomies.words }}
+  {{ $first := index (first 1 $weightedPages.Pages.ByDate) 0 }}
+  {{ if $first }}
+    {{ $result = $result | append (dict "word" $word "firstDate" $first.Date "firstPage" $first) }}
+  {{ end }}
 {{ end }}
 
 {{ return (sort $result "firstDate" "desc") }}


### PR DESCRIPTION
Shows the 10 most recently first-used words on the index page with a
link to a full sorted list. A single cached partial (newest-words.html)
builds the word-to-first-date mapping once per build, shared between
the index widget and the full list via partialCached with key "newest-words".

https://claude.ai/code/session_01Xk8jkc644DCELxxgUmnbpR