### PR TITLE
Tag Groundhog Day puzzles as holidays and add taxonomy copy

### DIFF
--- a/content/tags/groundhog-day/_index.md
+++ b/content/tags/groundhog-day/_index.md
@@ -3,3 +3,5 @@ title: Groundhog Day
 ---
 
 🐿️
+
+I definitely see a shadow.

--- a/content/w/2022-02-02/index.md
+++ b/content/w/2022-02-02/index.md
@@ -4,6 +4,7 @@ date: 2022-02-02T14:27:00.000-08:00
 tags:
   - backfill
   - groundhog-day
+  - holiday
 words:
   - eight
   - print

--- a/content/w/2023-02-02/index.md
+++ b/content/w/2023-02-02/index.md
@@ -1,7 +1,7 @@
 ---
 title: "593: 2023-02-02"
 date: 2023-02-02T00:35:09+01:00
-tags: ["groundhog-day"]
+tags: ["groundhog-day","holiday"]
 contests: ["2023-02-orate"]
 words: ["orate","quirk","shirk"]
 openers: ["orate"]

--- a/content/w/2024-02-02/index.md
+++ b/content/w/2024-02-02/index.md
@@ -1,7 +1,7 @@
 ---
 title: "958: 2024-02-02"
 date: 2024-02-02T11:17:23-08:00
-tags: []
+tags: ["groundhog-day","holiday"]
 git_branch: 2024-02-02_958
 contests: []
 words: ["psych","crown","climb","cleat","cleft"]

--- a/content/w/2025-02-02/index.md
+++ b/content/w/2025-02-02/index.md
@@ -1,7 +1,7 @@
 ---
 title: "1324: 2025-02-02"
 date: 2025-02-02T09:55:53-08:00
-tags: []
+tags: ["groundhog-day","holiday"]
 git_branch: 2025-02-02_1324
 contests: []
 words: ["score","chore"]

--- a/content/w/2026-02-02/index.md
+++ b/content/w/2026-02-02/index.md
@@ -1,7 +1,7 @@
 ---
 title: "1689: 2026-02-02"
 date: 2026-02-02T07:16:04-08:00
-tags: []
+tags: ["groundhog-day","holiday"]
 git_branch: 2026-02-02_1689
 contests: []
 words: ["pouch","crank","clear","cigar"]


### PR DESCRIPTION
### Motivation
- Ensure all Groundhog Day puzzle entries are discoverable via the `groundhog-day` tag and also classified as a `holiday` for consistent taxonomy grouping. 
- Add a short, personality-copy line to the Groundhog Day taxonomy term to provide context on the tag page.

### Description
- Added the `holiday` tag to existing Groundhog Day entries for February 2 in the archive at `content/w/2022-02-02/index.md`, `content/w/2023-02-02/index.md`, `content/w/2024-02-02/index.md`, `content/w/2025-02-02/index.md`, and `content/w/2026-02-02/index.md` so each now includes `"groundhog-day","holiday"` in frontmatter. 
- Updated the Groundhog Day taxonomy term page at `content/tags/groundhog-day/_index.md` with the line: “I definitely see a shadow.”

### Testing
- Located relevant entries with `rg --files content/w | rg '02-02/index.md$'` and `rg -n "groundhog-day|holiday" content` to identify targets and confirm presence of the tag. 
- Inspected files using `sed -n` and a verification loop `for f in content/w/*-02-02/index.md; do sed -n '1,12p' "$f"; done` to confirm updated frontmatter contains the expected tags. 
- Verified the taxonomy term file content with `sed -n '1,80p' content/tags/groundhog-day/_index.md` and confirmed the added copy, with all checks succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff8a8718e883238212d666f4fbb81b)