### PR TITLE
Add all-time GitHub-style activity grid to homepage

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -15,6 +15,7 @@
 
     <link rel="stylesheet" href="/dark.min.css">
     <link rel="stylesheet" href="/calendar.css">
+    <link rel="stylesheet" href="/activity-grid.css">
     {{- block "head" . }}{{ end -}}
   </head>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -63,6 +63,9 @@
     {{ end }}
   </div>
 
+<h2>📈 All-Time Activity</h2>
+{{ partial "activity-grid.html" $wordles }}
+
 <h2>🕰 Recent Puzzles</h2>
 <table>
   <tr>

--- a/layouts/partials/activity-grid.html
+++ b/layouts/partials/activity-grid.html
@@ -1,0 +1,84 @@
+{{/* GitHub-style all-time activity grid: one column per week, one row per weekday (Sun-Sat) */}}
+{{ $wordles := . }}
+{{ $puzzleMap := dict }}
+{{ range $p := $wordles }}
+  {{ $key := $p.Date.Format "2006-01-02" }}
+  {{ $puzzleMap = merge $puzzleMap (dict $key $p) }}
+{{ end }}
+
+{{ $sorted := $wordles.ByDate }}
+{{ if gt (len $sorted) 0 }}
+  {{ $weekdayMap := dict "Sunday" 0 "Monday" 1 "Tuesday" 2 "Wednesday" 3 "Thursday" 4 "Friday" 5 "Saturday" 6 }}
+
+  {{ $firstDate := (index $sorted 0).Date }}
+  {{ $lastDate := (index $sorted (sub (len $sorted) 1)).Date }}
+
+  {{ $firstW := index $weekdayMap ($firstDate.Format "Monday") }}
+  {{ $startDate := $firstDate.AddDate 0 0 (int (mul $firstW -1)) }}
+
+  {{ $lastW := index $weekdayMap ($lastDate.Format "Monday") }}
+  {{ $endDate := $lastDate.AddDate 0 0 (int (sub 6 $lastW)) }}
+
+  {{ $totalDays := add (div (sub $endDate.Unix $startDate.Unix) 86400) 1 }}
+  {{ $totalWeeks := div $totalDays 7 }}
+  {{ $now := now }}
+
+  <div class="activity-grid-scroll">
+    <div class="activity-grid-inner">
+      <div class="activity-grid-months" style="grid-template-columns: repeat({{ $totalWeeks }}, 11px);">
+        {{ $lastMonth := "" }}
+        {{ range $w := seq 0 (sub $totalWeeks 1) }}
+          {{ $weekStart := $startDate.AddDate 0 0 (int (mul $w 7)) }}
+          {{ $mName := $weekStart.Format "Jan" }}
+          <span class="activity-grid-month-label">{{ if ne $mName $lastMonth }}{{ $mName }}{{ $lastMonth = $mName }}{{ end }}</span>
+        {{ end }}
+      </div>
+      <div class="activity-grid" style="grid-template-columns: repeat({{ $totalWeeks }}, 11px); grid-template-rows: repeat(7, 11px);">
+        {{ range $w := seq 0 (sub $totalWeeks 1) }}
+          {{ range $d := seq 0 6 }}
+            {{ $date := $startDate.AddDate 0 0 (int (add (mul $w 7) $d)) }}
+            {{ $dateKey := $date.Format "2006-01-02" }}
+            {{ $puzzle := index $puzzleMap $dateKey }}
+            {{ $label := $date.Format "Jan 2, 2006" }}
+            {{ $level := "empty" }}
+            {{ with $puzzle }}
+              {{ $puzzleNum := index .Params.puzzles 0 }}
+              {{ if eq .Params.state.gameStatus "WIN" }}
+                {{ $guesses := partialCached "guess-count" . .File.Path }}
+                {{ $level = cond (le $guesses 2) "4" (cond (eq $guesses 3) "3" (cond (eq $guesses 4) "2" "1")) }}
+                {{ $label = printf "%s — %d, solved in %d" $label $puzzleNum $guesses }}
+              {{ else }}
+                {{ $level = "loss" }}
+                {{ $label = printf "%s — %d, lost" $label $puzzleNum }}
+              {{ end }}
+            {{ else }}
+              {{ if $date.After $now }}
+                {{ $level = "future" }}
+                {{ $label = "" }}
+              {{ else }}
+                {{ $label = printf "%s — no puzzle played" $label }}
+              {{ end }}
+            {{ end }}
+            {{ if $puzzle }}
+              <a class="activity-grid-day level-{{ $level }}" href="{{ $puzzle.RelPermalink }}" title="{{ $label }}"></a>
+            {{ else }}
+              <span class="activity-grid-day level-{{ $level }}"{{ with $label }} title="{{ . }}"{{ end }}></span>
+            {{ end }}
+          {{ end }}
+        {{ end }}
+      </div>
+    </div>
+  </div>
+
+  <div class="activity-grid-legend">
+    <span>Less</span>
+    <span class="activity-grid-day level-empty"></span>
+    <span class="activity-grid-day level-1"></span>
+    <span class="activity-grid-day level-2"></span>
+    <span class="activity-grid-day level-3"></span>
+    <span class="activity-grid-day level-4"></span>
+    <span>More</span>
+    <span class="activity-grid-day level-loss" style="margin-left: 0.75em"></span>
+    <span>Loss</span>
+  </div>
+{{ end }}

--- a/layouts/partials/activity-grid.html
+++ b/layouts/partials/activity-grid.html
@@ -1,4 +1,4 @@
-{{/* GitHub-style all-time activity grid: one column per week, one row per weekday (Sun-Sat) */}}
+{{/* GitHub-style activity grid, one strip per calendar year: weeks as columns, Sun-Sat as rows */}}
 {{ $wordles := . }}
 {{ $puzzleMap := dict }}
 {{ range $p := $wordles }}
@@ -9,65 +9,82 @@
 {{ $sorted := $wordles.ByDate }}
 {{ if gt (len $sorted) 0 }}
   {{ $weekdayMap := dict "Sunday" 0 "Monday" 1 "Tuesday" 2 "Wednesday" 3 "Thursday" 4 "Friday" 5 "Saturday" 6 }}
-
-  {{ $firstDate := (index $sorted 0).Date }}
-  {{ $lastDate := (index $sorted (sub (len $sorted) 1)).Date }}
-
-  {{ $firstW := index $weekdayMap ($firstDate.Format "Monday") }}
-  {{ $startDate := $firstDate.AddDate 0 0 (int (mul $firstW -1)) }}
-
-  {{ $lastW := index $weekdayMap ($lastDate.Format "Monday") }}
-  {{ $endDate := $lastDate.AddDate 0 0 (int (sub 6 $lastW)) }}
-
-  {{ $totalDays := add (div (sub $endDate.Unix $startDate.Unix) 86400) 1 }}
-  {{ $totalWeeks := div $totalDays 7 }}
   {{ $now := now }}
 
-  <div class="activity-grid-scroll">
-    <div class="activity-grid-inner">
-      <div class="activity-grid-months" style="grid-template-columns: repeat({{ $totalWeeks }}, 11px);">
-        {{ $lastMonth := "" }}
-        {{ range $w := seq 0 (sub $totalWeeks 1) }}
-          {{ $weekStart := $startDate.AddDate 0 0 (int (mul $w 7)) }}
-          {{ $mName := $weekStart.Format "Jan" }}
-          <span class="activity-grid-month-label">{{ if ne $mName $lastMonth }}{{ $mName }}{{ $lastMonth = $mName }}{{ end }}</span>
-        {{ end }}
-      </div>
-      <div class="activity-grid" style="grid-template-columns: repeat({{ $totalWeeks }}, 11px); grid-template-rows: repeat(7, 11px);">
-        {{ range $w := seq 0 (sub $totalWeeks 1) }}
-          {{ range $d := seq 0 6 }}
-            {{ $date := $startDate.AddDate 0 0 (int (add (mul $w 7) $d)) }}
-            {{ $dateKey := $date.Format "2006-01-02" }}
-            {{ $puzzle := index $puzzleMap $dateKey }}
-            {{ $label := $date.Format "Jan 2, 2006" }}
-            {{ $level := "empty" }}
-            {{ with $puzzle }}
-              {{ $puzzleNum := index .Params.puzzles 0 }}
-              {{ if eq .Params.state.gameStatus "WIN" }}
-                {{ $guesses := partialCached "guess-count" . .File.Path }}
-                {{ $level = cond (le $guesses 2) "4" (cond (eq $guesses 3) "3" (cond (eq $guesses 4) "2" "1")) }}
-                {{ $label = printf "%s — %d, solved in %d" $label $puzzleNum $guesses }}
-              {{ else }}
-                {{ $level = "loss" }}
-                {{ $label = printf "%s — %d, lost" $label $puzzleNum }}
+  {{ $firstYear := (index $sorted 0).Date.Year }}
+  {{ $lastYear := (index $sorted (sub (len $sorted) 1)).Date.Year }}
+
+  <div class="activity-grid-years">
+    {{ range $year := seq $lastYear -1 $firstYear }}
+      {{ $yearStart := time (printf "%04d-01-01" $year) }}
+      {{ $yearEnd := time (printf "%04d-12-31" $year) }}
+
+      {{ $firstW := index $weekdayMap ($yearStart.Format "Monday") }}
+      {{ $startDate := $yearStart.AddDate 0 0 (int (mul $firstW -1)) }}
+
+      {{ $lastW := index $weekdayMap ($yearEnd.Format "Monday") }}
+      {{ $endDate := $yearEnd.AddDate 0 0 (int (sub 6 $lastW)) }}
+
+      {{ $totalDays := add (div (sub $endDate.Unix $startDate.Unix) 86400) 1 }}
+      {{ $totalWeeks := div $totalDays 7 }}
+
+      <div class="activity-grid-year">
+        <div class="activity-grid-year-label">{{ $year }}</div>
+        <div class="activity-grid-scroll">
+          <div class="activity-grid-inner">
+            <div class="activity-grid-months" style="grid-template-columns: repeat({{ $totalWeeks }}, 11px);">
+              {{ $lastMonth := "" }}
+              {{ range $w := seq 0 (sub $totalWeeks 1) }}
+                {{ $weekStart := $startDate.AddDate 0 0 (int (mul $w 7)) }}
+                {{ $mName := "" }}
+                {{ if eq $weekStart.Year $year }}
+                  {{ $mName = $weekStart.Format "Jan" }}
+                {{ end }}
+                <span class="activity-grid-month-label">{{ if and (ne $mName "") (ne $mName $lastMonth) }}{{ $mName }}{{ $lastMonth = $mName }}{{ end }}</span>
               {{ end }}
-            {{ else }}
-              {{ if $date.After $now }}
-                {{ $level = "future" }}
-                {{ $label = "" }}
-              {{ else }}
-                {{ $label = printf "%s — no puzzle played" $label }}
+            </div>
+            <div class="activity-grid" style="grid-template-columns: repeat({{ $totalWeeks }}, 11px); grid-template-rows: repeat(7, 11px);">
+              {{ range $w := seq 0 (sub $totalWeeks 1) }}
+                {{ range $d := seq 0 6 }}
+                  {{ $date := $startDate.AddDate 0 0 (int (add (mul $w 7) $d)) }}
+                  {{ if ne $date.Year $year }}
+                    <span class="activity-grid-day level-pad"></span>
+                  {{ else }}
+                    {{ $dateKey := $date.Format "2006-01-02" }}
+                    {{ $puzzle := index $puzzleMap $dateKey }}
+                    {{ $label := $date.Format "Jan 2, 2006" }}
+                    {{ $level := "empty" }}
+                    {{ with $puzzle }}
+                      {{ $puzzleNum := index .Params.puzzles 0 }}
+                      {{ if eq .Params.state.gameStatus "WIN" }}
+                        {{ $guesses := partialCached "guess-count" . .File.Path }}
+                        {{ $level = cond (le $guesses 2) "4" (cond (eq $guesses 3) "3" (cond (eq $guesses 4) "2" "1")) }}
+                        {{ $label = printf "%s — %d, solved in %d" $label $puzzleNum $guesses }}
+                      {{ else }}
+                        {{ $level = "loss" }}
+                        {{ $label = printf "%s — %d, lost" $label $puzzleNum }}
+                      {{ end }}
+                    {{ else }}
+                      {{ if $date.After $now }}
+                        {{ $level = "future" }}
+                        {{ $label = "" }}
+                      {{ else }}
+                        {{ $label = printf "%s — no puzzle played" $label }}
+                      {{ end }}
+                    {{ end }}
+                    {{ if $puzzle }}
+                      <a class="activity-grid-day level-{{ $level }}" href="{{ $puzzle.RelPermalink }}" title="{{ $label }}"></a>
+                    {{ else }}
+                      <span class="activity-grid-day level-{{ $level }}"{{ with $label }} title="{{ . }}"{{ end }}></span>
+                    {{ end }}
+                  {{ end }}
+                {{ end }}
               {{ end }}
-            {{ end }}
-            {{ if $puzzle }}
-              <a class="activity-grid-day level-{{ $level }}" href="{{ $puzzle.RelPermalink }}" title="{{ $label }}"></a>
-            {{ else }}
-              <span class="activity-grid-day level-{{ $level }}"{{ with $label }} title="{{ . }}"{{ end }}></span>
-            {{ end }}
-          {{ end }}
-        {{ end }}
+            </div>
+          </div>
+        </div>
       </div>
-    </div>
+    {{ end }}
   </div>
 
   <div class="activity-grid-legend">

--- a/static/activity-grid.css
+++ b/static/activity-grid.css
@@ -1,0 +1,83 @@
+.activity-grid-scroll {
+  overflow-x: auto;
+  direction: rtl;
+  padding-bottom: 4px;
+}
+
+.activity-grid-inner {
+  direction: ltr;
+  display: inline-block;
+}
+
+.activity-grid-months {
+  display: grid;
+  grid-auto-flow: column;
+  column-gap: 2px;
+  font-size: 10px;
+  opacity: 0.6;
+  height: 14px;
+}
+
+.activity-grid-month-label {
+  white-space: nowrap;
+}
+
+.activity-grid {
+  display: grid;
+  grid-auto-flow: column;
+  gap: 2px;
+}
+
+.activity-grid-day {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  display: block;
+}
+
+a.activity-grid-day:hover,
+a.activity-grid-day:focus {
+  outline: 1px solid #dbdbdb;
+  outline-offset: 1px;
+}
+
+.activity-grid-day.level-empty {
+  background: #1b2a4a;
+}
+
+.activity-grid-day.level-future {
+  background: transparent;
+}
+
+.activity-grid-day.level-1 {
+  background: #0e4429;
+}
+
+.activity-grid-day.level-2 {
+  background: #006d32;
+}
+
+.activity-grid-day.level-3 {
+  background: #26a641;
+}
+
+.activity-grid-day.level-4 {
+  background: #39d353;
+}
+
+.activity-grid-day.level-loss {
+  background: #9c2b2b;
+}
+
+.activity-grid-legend {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  opacity: 0.7;
+  margin-top: 4px;
+}
+
+.activity-grid-legend .activity-grid-day {
+  display: inline-block;
+}

--- a/static/activity-grid.css
+++ b/static/activity-grid.css
@@ -1,11 +1,29 @@
+.activity-grid-years {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.activity-grid-year {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.activity-grid-year-label {
+  flex: 0 0 auto;
+  width: 2.5em;
+  padding-top: 14px;
+  font-weight: 600;
+  opacity: 0.85;
+}
+
 .activity-grid-scroll {
   overflow-x: auto;
-  direction: rtl;
   padding-bottom: 4px;
 }
 
 .activity-grid-inner {
-  direction: ltr;
   display: inline-block;
 }
 
@@ -45,7 +63,8 @@ a.activity-grid-day:focus {
   background: #1b2a4a;
 }
 
-.activity-grid-day.level-future {
+.activity-grid-day.level-future,
+.activity-grid-day.level-pad {
   background: transparent;
 }
 


### PR DESCRIPTION
Renders a scrollable, week-column/day-row grid spanning every day since
the first puzzle, colored by guesses-to-solve (or red for a loss), with
month labels and a legend. Placed on the homepage between the calendar
links and Recent Puzzles, inspired by
https://blog.omgmog.net/post/rebuilding-wordle-stats-from-whatsapp/.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011Nq7Weenwq3fzDJpvyzVyX