### PR TITLE
Bump GHA versions in hugo-build-profile workflow to node24 runtimes

### DIFF
--- a/.github/workflows/hugo-build-profile.yml
+++ b/.github/workflows/hugo-build-profile.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: install hugo with asdf as defined in .tool-versions manifest
-        uses: asdf-vm/actions/install@v1
+        uses: asdf-vm/actions/install@v4
       - name: build hugo site and capture build stats
         id: hugo_stats
         run: hugo --templateMetrics > hugo-build-stats.txt
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v9
         with:
           script: |
             let hugoStats = '';


### PR DESCRIPTION
actions/checkout@v3, asdf-vm/actions/install@v1, and actions/github-script@v6
all run on deprecated Node runtimes, triggering the Node 20 deprecation
warning and (for asdf-vm/actions@v1 specifically) an "Unable to locate
executable file: asdf" failure. Bump to checkout@v7, asdf-vm/actions/install@v4,
and github-script@v9, which all use runs.using: node24.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RLDasiY1fnQJaQbGHv6EnW